### PR TITLE
JENKINS-58544 Retry 3 times on 5XX from Jira API

### DIFF
--- a/src/main/java/com/atlassian/jira/cloud/jenkins/provider/HttpClientProvider.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/provider/HttpClientProvider.java
@@ -58,6 +58,7 @@ public class HttpClientProvider {
                 Thread.sleep(2000); // delay between each retry
             } catch (InterruptedException e) {
                 log.error("Retry delay interrupted: " + e.getMessage());
+                Thread.currentThread().interrupt();
             }
             response = chain.proceed(request);
             currentAttempt++;

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/provider/HttpClientProvider.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/provider/HttpClientProvider.java
@@ -1,23 +1,69 @@
 package com.atlassian.jira.cloud.jenkins.provider;
 
 import com.google.inject.Provides;
+import okhttp3.Interceptor;
+import okhttp3.Interceptor.Chain;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.time.Duration;
 
-/**
- * OkHttpClient with appropriate default timeouts
- */
+/** OkHttpClient with appropriate default timeouts */
 public class HttpClientProvider {
 
+    private static final Logger log = LoggerFactory.getLogger(HttpClientProvider.class);
     private final OkHttpClient httpClient;
 
     public HttpClientProvider() {
-        httpClient = new OkHttpClient.Builder()
-                .connectTimeout(Duration.ofMillis(5000))
-                .readTimeout(Duration.ofMillis(5000))
-                .writeTimeout(Duration.ofMillis(5000))
-                .build();
+        httpClient =
+                new OkHttpClient.Builder()
+                        .connectTimeout(Duration.ofMillis(5000))
+                        .readTimeout(Duration.ofMillis(5000))
+                        .writeTimeout(Duration.ofMillis(5000))
+                        .addInterceptor(retryInterceptor())
+                        .build();
+    }
+
+    private Interceptor retryInterceptor() {
+        return chain -> {
+            Request request = chain.request();
+            Response response = chain.proceed(request);
+            response = performRetry(chain, request, response);
+
+            return response;
+        };
+    }
+
+    private Response performRetry(
+            final Chain chain, final Request request, final Response originalResponse)
+            throws IOException {
+        Response response = originalResponse;
+        final int MAX_RETRIES = 3;
+        int currentAttempt = 1;
+
+        while (response.code() >= 500 && currentAttempt <= MAX_RETRIES) {
+            log.warn(
+                    String.format(
+                            "Received %d for request to %s. Retry attempt %d of %d.",
+                            response.code(),
+                            response.request().url(),
+                            currentAttempt,
+                            MAX_RETRIES));
+            response.close();
+            try {
+                Thread.sleep(2000); // delay between each retry
+            } catch (InterruptedException e) {
+                log.error("Retry delay interrupted: " + e.getMessage());
+            }
+            response = chain.proceed(request);
+            currentAttempt++;
+        }
+
+        return response;
     }
 
     @Provides

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/HttpClientProviderTestGenerator.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/HttpClientProviderTestGenerator.java
@@ -1,0 +1,32 @@
+package com.atlassian.jira.cloud.jenkins;
+
+import com.atlassian.jira.cloud.jenkins.provider.HttpClientProviderTest;
+import okhttp3.mockwebserver.MockResponse;
+
+public class HttpClientProviderTestGenerator {
+
+    public static void succeedWith2XXOnInitialAttempt(HttpClientProviderTest testClass) {
+        mockResponse(testClass, 202);
+    }
+
+    public static void failWith4XXOnInitialAttempt(HttpClientProviderTest testClass) {
+        mockResponse(testClass, 404);
+    }
+
+    public static void failWith503AndThenSucceed2XX(HttpClientProviderTest testClass) {
+        mockResponse(testClass, 503);
+        mockResponse(testClass, 202);
+    }
+
+    public static void failWith503ForAllAttempts(HttpClientProviderTest testClass) {
+        mockResponse(testClass, 503);
+        mockResponse(testClass, 503);
+        mockResponse(testClass, 503);
+        mockResponse(testClass, 503);
+    }
+
+    private static void mockResponse(HttpClientProviderTest testClass, int responseCode) {
+        testClass.server.enqueue(new MockResponse().setBody("test-response").setResponseCode(responseCode));
+    }
+
+}

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/provider/HttpClientProviderTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/provider/HttpClientProviderTest.java
@@ -1,0 +1,83 @@
+package com.atlassian.jira.cloud.jenkins.provider;
+
+import com.atlassian.jira.cloud.jenkins.BaseMockServerTest;
+import com.atlassian.jira.cloud.jenkins.HttpClientProviderTestGenerator;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HttpClientProviderTest extends BaseMockServerTest {
+
+    @Inject
+    private OkHttpClient httpClient;
+
+    @Before
+    public void setup() throws IOException {
+        super.setup();
+        httpClient = new HttpClientProvider().httpClient();
+    }
+
+    @Test
+    public void testNoRetryFor2XX() throws IOException {
+        // setup
+        HttpClientProviderTestGenerator.succeedWith2XXOnInitialAttempt(this);
+        final Request request = getRequest();
+
+        // execute
+        final Response response = httpClient.newCall(request).execute();
+
+        // verify
+        assertThat(response.code()).isEqualTo(202);
+    }
+
+    @Test
+    public void testNoRetryFor4XX() throws IOException {
+        // setup
+        HttpClientProviderTestGenerator.failWith4XXOnInitialAttempt(this);
+        final Request request = getRequest();
+
+        // execute
+        final Response response = httpClient.newCall(request).execute();
+
+        // verify
+        assertThat(response.code()).isEqualTo(404);
+    }
+
+    @Test
+    public void testRetryOnceFor5XXAndSucceed() throws IOException {
+        // setup
+        HttpClientProviderTestGenerator.failWith503AndThenSucceed2XX(this);
+        final Request request = getRequest();
+
+        // execute
+        final Response response = httpClient.newCall(request).execute();
+
+        // verify
+        assertThat(response.code()).isEqualTo(202);
+    }
+
+    @Test
+    public void testFailFor5XXAfterThreeRetries() throws IOException {
+        // setup
+        HttpClientProviderTestGenerator.failWith503ForAllAttempts(this);
+        final Request request = getRequest();
+
+        // execute
+        final Response response = httpClient.newCall(request).execute();
+
+        // verify
+        assertThat(response.code()).isEqualTo(503);
+    }
+
+    private Request getRequest() {
+        return new Request.Builder().url(server.url("/test")).build();
+    }
+
+}

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/provider/HttpClientProviderTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/provider/HttpClientProviderTest.java
@@ -35,6 +35,7 @@ public class HttpClientProviderTest extends BaseMockServerTest {
 
         // verify
         assertThat(response.code()).isEqualTo(202);
+        assertThat(server.getRequestCount()).isEqualTo(1); // first request only
     }
 
     @Test
@@ -48,6 +49,7 @@ public class HttpClientProviderTest extends BaseMockServerTest {
 
         // verify
         assertThat(response.code()).isEqualTo(404);
+        assertThat(server.getRequestCount()).isEqualTo(1); // first request only
     }
 
     @Test
@@ -61,6 +63,7 @@ public class HttpClientProviderTest extends BaseMockServerTest {
 
         // verify
         assertThat(response.code()).isEqualTo(202);
+        assertThat(server.getRequestCount()).isEqualTo(2); // 1 actual request + 1 retry
     }
 
     @Test
@@ -74,6 +77,7 @@ public class HttpClientProviderTest extends BaseMockServerTest {
 
         // verify
         assertThat(response.code()).isEqualTo(503);
+        assertThat(server.getRequestCount()).isEqualTo(4); // 1 actual request + 3 retries
     }
 
     private Request getRequest() {


### PR DESCRIPTION
If we receive 5XX when submitting builds or deployments, we should retry before giving up.

Tested using a mock server locally, to return 503 for 1st and 2nd attempt and 202 on 3rd attempt:

```
Jul 19, 2019 3:09:07 AM com.atlassian.jira.cloud.jenkins.provider.HttpClientProvider performRetry
WARNING: Received 503 for request to http://lr-retry.au.ngrok.io/jira/builds/0.1/cloud/ccc15b90-71d1-4f81-9f55-877df49250cd/bulk. Retry attempt 1 of 3.
Jul 19, 2019 3:09:09 AM com.atlassian.jira.cloud.jenkins.provider.HttpClientProvider performRetry
WARNING: Received 503 for request to http://lr-retry.au.ngrok.io/jira/builds/0.1/cloud/ccc15b90-71d1-4f81-9f55-877df49250cd/bulk. Retry attempt 2 of 3.
GOT CONTEXT FOR Deploy - Staging
Jul 19, 2019 3:09:12 AM com.atlassian.jira.cloud.jenkins.provider.HttpClientProvider performRetry
WARNING: Received 503 for request to http://lr-retry.au.ngrok.io/jira/deployments/0.1/cloud/ccc15b90-71d1-4f81-9f55-877df49250cd/bulk. Retry attempt 1 of 3.
Jul 19, 2019 3:09:14 AM com.atlassian.jira.cloud.jenkins.provider.HttpClientProvider performRetry
WARNING: Received 503 for request to http://lr-retry.au.ngrok.io/jira/deployments/0.1/cloud/ccc15b90-71d1-4f81-9f55-877df49250cd/bulk. Retry attempt 2 of 3.
```