### PR TITLE
JENKINS-59862 Validate deployment info environment parameters.

### DIFF
--- a/src/main/java/com/atlassian/jira/cloud/jenkins/common/response/JiraSendInfoResponse.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/common/response/JiraSendInfoResponse.java
@@ -22,6 +22,7 @@ public abstract class JiraSendInfoResponse implements Serializable {
         FAILURE_DEPLOYMENTS_API_RESPONSE,
         FAILURE_UNEXPECTED_RESPONSE,
         SKIPPED_ISSUE_KEYS_NOT_FOUND,
+        FAILURE_ENVIRONMENT_INVALID
     }
 
     private final Status status;

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/EnvironmentValidator.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/EnvironmentValidator.java
@@ -1,0 +1,39 @@
+package com.atlassian.jira.cloud.jenkins.deploymentinfo.service;
+
+import com.atlassian.jira.cloud.jenkins.deploymentinfo.client.model.Environment;
+import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public final class EnvironmentValidator {
+
+    private static final Set<String> ALLOWED_ENVS =
+            ImmutableSet.of("development", "testing", "staging", "production", "unmapped");
+
+    public static List<String> validate(final Environment environment) {
+        final List<String> errorMessages = new ArrayList<>();
+
+        if (StringUtils.isBlank(environment.getId())) {
+            errorMessages.add("The parameter environmentId is required.");
+        }
+
+        if (StringUtils.isBlank(environment.getDisplayName())) {
+            errorMessages.add("The parameter environmentName is required.");
+        }
+
+        if (!isAllowedEnvironmentType(environment.getType())) {
+            errorMessages.add(
+                    "The parameter environmentType is not valid. Allowed values are: "
+                            + ALLOWED_ENVS);
+        }
+
+        return errorMessages;
+    }
+
+    private static boolean isAllowedEnvironmentType(final String environmentTyp) {
+        return StringUtils.isNotBlank(environmentTyp) && ALLOWED_ENVS.contains(environmentTyp);
+    }
+}

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/JiraDeploymentInfoResponse.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/JiraDeploymentInfoResponse.java
@@ -4,10 +4,20 @@ import com.atlassian.jira.cloud.jenkins.Messages;
 import com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse;
 import com.atlassian.jira.cloud.jenkins.deploymentinfo.client.model.DeploymentApiResponse;
 
+import java.util.List;
+
 public class JiraDeploymentInfoResponse extends JiraSendInfoResponse {
 
     public JiraDeploymentInfoResponse(final Status status, final String message) {
         super(status, message);
+    }
+
+    public static JiraSendInfoResponse failureEnvironmentInvalid(
+            final String jiraSite, final List<String> errorMessages) {
+        final String message =
+                Messages.JiraDeploymentInfoResponse_FAILURE_ENVIRONMENT_INVALID(
+                        String.join(" ", errorMessages));
+        return new JiraDeploymentInfoResponse(Status.FAILURE_ENVIRONMENT_INVALID, message);
     }
 
     public static JiraSendInfoResponse skippedIssueKeysNotFound(final String jiraSite) {

--- a/src/main/resources/com/atlassian/jira/cloud/jenkins/Messages.properties
+++ b/src/main/resources/com/atlassian/jira/cloud/jenkins/Messages.properties
@@ -19,3 +19,4 @@ JiraDeploymentInfoResponse.FAILURE_UNKNOWN_ISSUE_KEYS=Failed to send deployment 
 JiraDeploymentInfoResponse.FAILURE_DEPLOYMENTS_API_RESPONSE=Failed to send deployment information to Jira: {0}. {1}
 JiraDeploymentInfoResponse.FAILURE_UNEXPECTED_RESPONSE=Unexpected DeploymentApi response.
 JiraDeploymentInfoResponse.SKIPPED_ISSUE_KEYS_NOT_FOUND=No issue keys found in the change log. Not sending deployment information to Jira: {0}.
+JiraDeploymentInfoResponse.FAILURE_ENVIRONMENT_INVALID=The deployment environment is not valid. {0}

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/JiraDeploymentInfoSenderImplTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/JiraDeploymentInfoSenderImplTest.java
@@ -202,9 +202,53 @@ public class JiraDeploymentInfoSenderImplTest {
         assertThat(message).isNotBlank();
     }
 
+    @Test
+    public void testSendDeploymentInfo_whenMissingEnvironmentIdAndEnvironmentName() {
+        // given
+        final JiraDeploymentInfoRequest request = createRequest(null, null, null);
+
+        // when
+        final JiraSendInfoResponse response = classUnderTest.sendDeploymentInfo(request);
+
+        // then
+        assertThat(response.getStatus())
+                .isEqualTo(JiraSendInfoResponse.Status.FAILURE_ENVIRONMENT_INVALID);
+        assertThat(response.getMessage())
+                .isEqualTo(
+                        "The deployment environment is not valid. "
+                                + "The parameter environmentId is required. The parameter environmentName is required.");
+    }
+
+    @Test
+    public void testSendDeploymentInfo_whenNotAllowedEnvironmentType() {
+        // given
+        final JiraDeploymentInfoRequest request =
+                createRequest("prod-east", "Production East", "foobar");
+
+        // when
+        final JiraSendInfoResponse response = classUnderTest.sendDeploymentInfo(request);
+
+        // then
+        assertThat(response.getStatus())
+                .isEqualTo(JiraSendInfoResponse.Status.FAILURE_ENVIRONMENT_INVALID);
+        assertThat(response.getMessage())
+                .isEqualTo(
+                        "The deployment environment is not valid. "
+                                + "The parameter environmentType is not valid. "
+                                + "Allowed values are: [development, testing, staging, production, unmapped]");
+    }
+
     private JiraDeploymentInfoRequest createRequest() {
         return new JiraDeploymentInfoRequest(
                 SITE, ENVIRONMENT_ID, ENVIRONMENT_NAME, ENVIRONMENT_TYPE, mockWorkflowRun());
+    }
+
+    private JiraDeploymentInfoRequest createRequest(
+            final String environmentId,
+            final String environmentName,
+            final String environmentType) {
+        return new JiraDeploymentInfoRequest(
+                SITE, environmentId, environmentName, environmentType, mockWorkflowRun());
     }
 
     private void setupMocks() {


### PR DESCRIPTION
The following changes have been applied in this pull request:

- Strict validation of the deployment info parameters: environmentId and environmentName are required parameters and environmentType is optional
- If the environmentType parameter is not provided, we use "unmapped" environmentType as the fallback value