### PR TITLE
JENKINS-59955 Add provider metadata field

### DIFF
--- a/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/client/model/Builds.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/client/model/Builds.java
@@ -2,20 +2,21 @@ package com.atlassian.jira.cloud.jenkins.buildinfo.client.model;
 
 import com.atlassian.jira.cloud.jenkins.common.client.JiraRequest;
 import com.atlassian.jira.cloud.jenkins.common.client.model.Properties;
+import com.atlassian.jira.cloud.jenkins.common.client.model.ProviderMetadata;
 
 import java.util.Collections;
 import java.util.List;
 
-/**
- * This represents the payload for the API request to submit list of builds
- */
+/** This represents the payload for the API request to submit list of builds */
 public class Builds implements JiraRequest {
     private List<JiraBuildInfo> builds;
     private Properties properties;
+    private ProviderMetadata providerMetadata;
 
     public Builds(final JiraBuildInfo jiraBuildInfo) {
         this.builds = Collections.singletonList(jiraBuildInfo);
         this.properties = new Properties();
+        this.providerMetadata = new ProviderMetadata();
     }
 
     public List<JiraBuildInfo> getBuilds() {
@@ -24,5 +25,9 @@ public class Builds implements JiraRequest {
 
     public Properties getProperties() {
         return properties;
+    }
+
+    public ProviderMetadata getProviderMetadata() {
+        return providerMetadata;
     }
 }

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/common/client/model/ProviderMetadata.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/common/client/model/ProviderMetadata.java
@@ -1,0 +1,9 @@
+package com.atlassian.jira.cloud.jenkins.common.client.model;
+
+/** This object represents provider metadata, i.e. the source/system the data is coming from. */
+public class ProviderMetadata {
+
+    public String getProduct() {
+        return "jenkins";
+    }
+}

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/client/model/Deployments.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/client/model/Deployments.java
@@ -2,6 +2,7 @@ package com.atlassian.jira.cloud.jenkins.deploymentinfo.client.model;
 
 import com.atlassian.jira.cloud.jenkins.common.client.JiraRequest;
 import com.atlassian.jira.cloud.jenkins.common.client.model.Properties;
+import com.atlassian.jira.cloud.jenkins.common.client.model.ProviderMetadata;
 
 import java.util.Collections;
 import java.util.List;
@@ -10,10 +11,12 @@ import java.util.List;
 public class Deployments implements JiraRequest {
     private List<JiraDeploymentInfo> deployments;
     private Properties properties;
+    private ProviderMetadata providerMetadata;
 
     public Deployments(final JiraDeploymentInfo jiraDeploymentInfo) {
         this.deployments = Collections.singletonList(jiraDeploymentInfo);
         this.properties = new Properties();
+        this.providerMetadata = new ProviderMetadata();
     }
 
     public List<JiraDeploymentInfo> getDeployments() {
@@ -22,5 +25,9 @@ public class Deployments implements JiraRequest {
 
     public Properties getProperties() {
         return properties;
+    }
+
+    public ProviderMetadata getProviderMetadata() {
+        return providerMetadata;
     }
 }

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/buildinfo/client/BuildPayloadBuilderTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/buildinfo/client/BuildPayloadBuilderTest.java
@@ -24,6 +24,7 @@ public class BuildPayloadBuilderTest extends BaseUnitTest {
 
         final JiraBuildInfo buildInfo = buildPayload.getBuilds().get(0);
         // then
+        assertThat(buildPayload.getProviderMetadata().getProduct()).isEqualTo("jenkins");
         assertThat(buildInfo.getPipelineId()).isEqualTo(runWrapper.getFullProjectName());
         assertThat(buildInfo.getBuildNumber()).isEqualTo(runWrapper.getNumber());
         assertThat(buildInfo.getDisplayName()).isEqualTo(runWrapper.getDisplayName());
@@ -42,6 +43,7 @@ public class BuildPayloadBuilderTest extends BaseUnitTest {
         final JiraBuildInfo buildInfo = buildPayload.getBuilds().get(0);
 
         // then
+        assertThat(buildPayload.getProviderMetadata().getProduct()).isEqualTo("jenkins");
         assertThat(buildInfo.getPipelineId()).isEqualTo(runWrapper.getFullProjectName());
         assertThat(buildInfo.getBuildNumber()).isEqualTo(runWrapper.getNumber());
         assertThat(buildInfo.getDisplayName()).isEqualTo(runWrapper.getDisplayName());

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/client/DeploymentPayloadBuilderTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/client/DeploymentPayloadBuilderTest.java
@@ -26,6 +26,7 @@ public class DeploymentPayloadBuilderTest extends BaseUnitTest {
 
         final JiraDeploymentInfo jiraDeploymentInfo = deployments.getDeployments().get(0);
         // then
+        assertThat(deployments.getProviderMetadata().getProduct()).isEqualTo("jenkins");
         assertDeploymentResult(runWrapper, jiraDeploymentInfo, "successful");
     }
 
@@ -38,6 +39,7 @@ public class DeploymentPayloadBuilderTest extends BaseUnitTest {
 
         final JiraDeploymentInfo jiraDeploymentInfo = deployments.getDeployments().get(0);
         // then
+        assertThat(deployments.getProviderMetadata().getProduct()).isEqualTo("jenkins");
         assertDeploymentResult(runWrapper, jiraDeploymentInfo, "failed");
     }
 


### PR DESCRIPTION
In this PR, I'm adding an additional (optional) ProviderMetadata field to Builds and Deployment payloads. The additional field will allow us to reliably identify the source of data.