### PR TITLE
Add rate limiter for jira-api calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
         <assertj.version>3.11.1</assertj.version>
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
         <archunit.version>0.9.2</archunit.version>
+        <resilience4j.version>1.4.0</resilience4j.version>
+        <slf4j.version>1.7.26</slf4j.version>
     </properties>
     <name>Atlassian Jira Software Cloud</name>
     <description>Atlassian Jira Software Cloud Jenkins Integration</description>
@@ -89,6 +91,20 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>${okhttp.version}</version>
+        </dependency>
+
+        <!-- resilience4j -->
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-ratelimiter</artifactId>
+            <version>${resilience4j.version}</version>
+        </dependency>
+
+        <!-- slf4j api -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
         <!-- Jackson -->
         <dependency>

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/Config.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/Config.java
@@ -1,6 +1,24 @@
 package com.atlassian.jira.cloud.jenkins;
 
+import com.google.common.collect.ImmutableMap;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+
+import java.time.Duration;
+
 public interface Config {
 
     String ATLASSIAN_API_URL = "https://api.atlassian.com";
+    String ATLASSIAN_RATE_LIMITER_CONFIG = "atl";
+
+    RateLimiterConfig DEFAULT_RATE_LIMITER_CONFIG =
+            RateLimiterConfig.custom()
+                    .limitRefreshPeriod(Duration.ofSeconds(1))
+                    .limitRefreshPeriod(Duration.ofMinutes(5))
+                    .limitForPeriod(5000)
+                    .build();
+
+    RateLimiterRegistry RATE_LIMITER_REGISTRY =
+            RateLimiterRegistry.of(
+                    ImmutableMap.of(ATLASSIAN_RATE_LIMITER_CONFIG, DEFAULT_RATE_LIMITER_CONFIG));
 }

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/common/client/JiraApi.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/common/client/JiraApi.java
@@ -43,19 +43,19 @@ public class JiraApi {
      *     DeploymentApiResponse
      * @param cloudId Jira Cloud Id
      * @param accessToken Access token generated from Atlassian API
-     * @param jiraSiteUrl Jira site URL
+     * @param clientId oAuth client id
      * @param jiraRequest An assembled payload to be submitted to Jira
      * @return Response from the API
      */
     public <ResponseEntity> PostUpdateResult<ResponseEntity> postUpdate(
             final String cloudId,
             final String accessToken,
-            final String jiraSiteUrl,
+            final String clientId,
             final JiraRequest jiraRequest,
             final Class<ResponseEntity> responseClass) {
         try {
             final String requestPayload = objectMapper.writeValueAsString(jiraRequest);
-            final Request request = getRequest(cloudId, accessToken, requestPayload);
+            final Request request = getRequest(cloudId, accessToken, requestPayload, clientId);
             final Response response = httpClient.newCall(request).execute();
 
             checkForErrorResponse(response);
@@ -120,11 +120,12 @@ public class JiraApi {
     }
 
     private Request getRequest(
-            final String cloudId, final String accessToken, final String requestPayload) {
+            final String cloudId, final String accessToken, final String requestPayload, final String clientId) {
         RequestBody body = RequestBody.create(JSON, requestPayload);
         return new Request.Builder()
                 .url(String.format(this.apiEndpoint, cloudId))
                 .addHeader("Authorization", "Bearer " + accessToken)
+                .tag(String.class, clientId)
                 .post(body)
                 .build();
     }

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/common/client/JiraApi.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/common/client/JiraApi.java
@@ -3,6 +3,7 @@ package com.atlassian.jira.cloud.jenkins.common.client;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -72,6 +73,8 @@ public class JiraApi {
                             "Server exception when submitting update to Jira: %s", e.getMessage()));
         } catch (ApiUpdateFailedException e) {
             return handleError(e.getMessage());
+        } catch (RequestNotPermitted e) {
+            return handleError("Your OAuth client riches Jira's limits " + e.getMessage());
         } catch (Exception e) {
             return handleError(
                     String.format(

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/common/client/JiraApi.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/common/client/JiraApi.java
@@ -74,7 +74,7 @@ public class JiraApi {
         } catch (ApiUpdateFailedException e) {
             return handleError(e.getMessage());
         } catch (RequestNotPermitted e) {
-            return handleError("Your OAuth client riches Jira's limits " + e.getMessage());
+            return handleError("Your OAuth client reached Jira's limits " + e.getMessage());
         } catch (Exception e) {
             return handleError(
                     String.format(

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/provider/HttpClientProvider.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/provider/HttpClientProvider.java
@@ -40,7 +40,7 @@ public class HttpClientProvider {
     private Interceptor rateLimiterInterceptor(final RateLimiterRegistry rateLimiterRegistry) {
         return chain -> {
             final Request request = chain.request();
-            final String clientId = request.header("clientId");
+            final String clientId = request.tag(String.class);
             if (clientId != null) {
                 final RateLimiter rateLimiter =
                         rateLimiterRegistry.rateLimiter(
@@ -48,17 +48,15 @@ public class HttpClientProvider {
                 try {
                     return rateLimiter.executeCallable(() -> chain.proceed(request));
                 } catch (Exception e) {
-                    // case Http client errors
-                    // it should be always IOException since it's a contract of Interceptor
                     if (e instanceof IOException) {
+                        // case Http client errors
+                        // it should be always IOException since it's a contract of Interceptor
                         throw (IOException) e;
-                    }
-                    // case over limits
-                    else if (e instanceof RequestNotPermitted) {
+                    } else if (e instanceof RequestNotPermitted) {
+                        // case over limits
                         throw (RequestNotPermitted) e;
-                    }
-                    // all other cases
-                    else {
+                    } else {
+                        // all other cases
                         throw new RuntimeException(e);
                     }
                 }

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/HttpClientProviderTestGenerator.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/HttpClientProviderTestGenerator.java
@@ -3,10 +3,17 @@ package com.atlassian.jira.cloud.jenkins;
 import com.atlassian.jira.cloud.jenkins.provider.HttpClientProviderTest;
 import okhttp3.mockwebserver.MockResponse;
 
+import java.util.stream.IntStream;
+
 public class HttpClientProviderTestGenerator {
 
     public static void succeedWith2XXOnInitialAttempt(HttpClientProviderTest testClass) {
         mockResponse(testClass, 202);
+    }
+
+    public static void succeedWith2XXForAttempts(
+            HttpClientProviderTest testClass, int numberOfAttempts) {
+        IntStream.range(0, numberOfAttempts).forEach(ignore -> mockResponse(testClass, 202));
     }
 
     public static void failWith4XXOnInitialAttempt(HttpClientProviderTest testClass) {
@@ -28,5 +35,4 @@ public class HttpClientProviderTestGenerator {
     private static void mockResponse(HttpClientProviderTest testClass, int responseCode) {
         testClass.server.enqueue(new MockResponse().setBody("test-response").setResponseCode(responseCode));
     }
-
 }

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/common/client/BuildsApiTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/common/client/BuildsApiTest.java
@@ -6,14 +6,17 @@ import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.BuildApiResponse;
 import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.Builds;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import javax.inject.Inject;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class BuildsApiTest extends BaseMockServerTest {
 
@@ -24,6 +27,7 @@ public class BuildsApiTest extends BaseMockServerTest {
     private static String CLOUD_ID = "cloud_id";
     private static String ACCESS_TOKEN = "access_token";
     private static String JIRA_SITE_URL = "https://site.atlassian.net";
+    private static String CLIENT_ID = "client_id";
 
     @Before
     public void setup() throws IOException {
@@ -42,7 +46,7 @@ public class BuildsApiTest extends BaseMockServerTest {
                 buildsApi.postUpdate(
                         CLOUD_ID,
                         ACCESS_TOKEN,
-                        JIRA_SITE_URL,
+                        CLIENT_ID,
                         mock(Builds.class),
                         BuildApiResponse.class);
 
@@ -66,7 +70,7 @@ public class BuildsApiTest extends BaseMockServerTest {
                 buildsApi.postUpdate(
                         CLOUD_ID,
                         ACCESS_TOKEN,
-                        JIRA_SITE_URL,
+                        CLIENT_ID,
                         mock(Builds.class),
                         BuildApiResponse.class);
 
@@ -94,7 +98,7 @@ public class BuildsApiTest extends BaseMockServerTest {
                 buildsApi.postUpdate(
                         CLOUD_ID,
                         ACCESS_TOKEN,
-                        JIRA_SITE_URL,
+                        CLIENT_ID,
                         mock(Builds.class),
                         BuildApiResponse.class);
 
@@ -124,7 +128,7 @@ public class BuildsApiTest extends BaseMockServerTest {
                 buildsApi.postUpdate(
                         CLOUD_ID,
                         ACCESS_TOKEN,
-                        JIRA_SITE_URL,
+                        CLIENT_ID,
                         mock(Builds.class),
                         BuildApiResponse.class);
 
@@ -144,7 +148,7 @@ public class BuildsApiTest extends BaseMockServerTest {
                 buildsApi.postUpdate(
                         CLOUD_ID,
                         ACCESS_TOKEN,
-                        JIRA_SITE_URL,
+                        CLIENT_ID,
                         mock(Builds.class),
                         BuildApiResponse.class);
 
@@ -152,5 +156,28 @@ public class BuildsApiTest extends BaseMockServerTest {
         assertThat(result.getErrorMessage().isPresent()).isTrue();
         assertThat(result.getErrorMessage().get())
                 .isEqualTo("Error response code 500 when submitting update to Jira");
+    }
+
+    @Test
+    public void testRequestContainsTags() {
+        // setup
+        final OkHttpClient mockHttpClient = mock(OkHttpClient.class);
+        final JiraApi jiraApi = new JiraApi(mockHttpClient, objectMapper, JIRA_SITE_URL);
+        final ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+
+        // execute
+        final PostUpdateResult<BuildApiResponse> result =
+                jiraApi.postUpdate(
+                        CLOUD_ID,
+                        ACCESS_TOKEN,
+                        CLIENT_ID,
+                        mock(Builds.class),
+                        BuildApiResponse.class);
+
+        // verify
+        verify(mockHttpClient).newCall(requestCaptor.capture());
+        final Request request = requestCaptor.getValue();
+        assertThat(request.tag(String.class)).isEqualTo(CLIENT_ID);
+
     }
 }

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/provider/HttpClientProviderTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/provider/HttpClientProviderTest.java
@@ -120,7 +120,7 @@ public class HttpClientProviderTest extends BaseMockServerTest {
         final int numberOfAttempts = LIMIT_FOR_PERIOD + 1;
         HttpClientProviderTestGenerator.succeedWith2XXForAttempts(this, numberOfAttempts);
         final String clientId = "1";
-        final Request request = getRequest().newBuilder().addHeader("clientId", clientId).build();
+        final Request request = getRequest().newBuilder().tag(String.class, clientId).build();
 
         // execute
         try {
@@ -143,7 +143,6 @@ public class HttpClientProviderTest extends BaseMockServerTest {
         // setup
         final int numberOfAttempts = LIMIT_FOR_PERIOD + 1;
         HttpClientProviderTestGenerator.succeedWith2XXForAttempts(this, numberOfAttempts);
-        final String clientId = "1";
         final Request request = getRequest();
 
         // execute

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/provider/HttpClientProviderTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/provider/HttpClientProviderTest.java
@@ -1,7 +1,11 @@
 package com.atlassian.jira.cloud.jenkins.provider;
 
 import com.atlassian.jira.cloud.jenkins.BaseMockServerTest;
+import com.atlassian.jira.cloud.jenkins.Config;
 import com.atlassian.jira.cloud.jenkins.HttpClientProviderTestGenerator;
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -11,10 +15,15 @@ import org.junit.Test;
 
 import javax.inject.Inject;
 import java.io.IOException;
+import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class HttpClientProviderTest extends BaseMockServerTest {
+
+    private static final int LIMIT_FOR_PERIOD = 3;
 
     @Inject private OkHttpClient httpClient;
 
@@ -22,6 +31,15 @@ public class HttpClientProviderTest extends BaseMockServerTest {
     public void setup() throws IOException {
         super.setup();
         httpClient = new HttpClientProvider().httpClient();
+        final RateLimiterRegistry rateLimiterRegistry = Config.RATE_LIMITER_REGISTRY;
+
+        rateLimiterRegistry.addConfiguration(
+                Config.ATLASSIAN_RATE_LIMITER_CONFIG,
+                RateLimiterConfig.custom()
+                        .limitForPeriod(LIMIT_FOR_PERIOD)
+                        .limitRefreshPeriod(Duration.ofMinutes(1))
+                        .timeoutDuration(Duration.ofSeconds(1))
+                        .build());
     }
 
     @Test
@@ -94,6 +112,47 @@ public class HttpClientProviderTest extends BaseMockServerTest {
         final RecordedRequest recordedRequest = server.takeRequest();
         assertThat(recordedRequest.getHeader("User-Agent"))
                 .isEqualTo("atlassian-jira-software-cloud-plugin");
+    }
+
+    @Test
+    public void testClientRichLimits() {
+        // setup
+        final int numberOfAttempts = LIMIT_FOR_PERIOD + 1;
+        HttpClientProviderTestGenerator.succeedWith2XXForAttempts(this, numberOfAttempts);
+        final String clientId = "1";
+        final Request request = getRequest().newBuilder().addHeader("clientId", clientId).build();
+
+        // execute
+        try {
+            for (int i = 0; i < numberOfAttempts; i++) {
+                httpClient.newCall(request).execute();
+            }
+        }
+
+        // verify
+        catch (Exception e) {
+            assertTrue(e instanceof RequestNotPermitted);
+            assertEquals(
+                    String.format("RateLimiter '%s' does not permit further calls", clientId),
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void testClientIdDoesntProvided_limitsDidntRich() throws Exception {
+        // setup
+        final int numberOfAttempts = LIMIT_FOR_PERIOD + 1;
+        HttpClientProviderTestGenerator.succeedWith2XXForAttempts(this, numberOfAttempts);
+        final String clientId = "1";
+        final Request request = getRequest();
+
+        // execute
+        for (int i = 0; i < numberOfAttempts; i++) {
+            final Response response = httpClient.newCall(request).execute();
+        }
+
+        // verify
+        assertThat(server.getRequestCount()).isEqualTo(numberOfAttempts);
     }
 
     private Request getRequest() {


### PR DESCRIPTION
Changes in pr:
1. add `resilience4j-ratelimiter` to implement rate-limiting. It needs to protect Jira from kind of DDoS. I'm planning to add a new pipeline step wich main work will be wrapped in `waitUntil`.