### PR TITLE
NO-JIRA Override issue extractor with provided list of keys

### DIFF
--- a/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/pipeline/JiraSendDeploymentInfoStep.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/pipeline/JiraSendDeploymentInfoStep.java
@@ -42,6 +42,7 @@ public class JiraSendDeploymentInfoStep extends Step implements Serializable {
     private String state;
     private List<String> serviceIds = new ArrayList<>();
     private Boolean enableGating = Boolean.FALSE;
+    private List<String> issueKeys = new ArrayList<>();
 
     @DataBoundConstructor
     public JiraSendDeploymentInfoStep(
@@ -116,9 +117,18 @@ public class JiraSendDeploymentInfoStep extends Step implements Serializable {
         return enableGating;
     }
 
+    public List<String> getIssueKeys() {
+        return issueKeys;
+    }
+
     @DataBoundSetter
     public void setEnableGating(final Boolean enableGating) {
         this.enableGating = enableGating;
+    }
+
+    @DataBoundSetter
+    public void setIssueKeys(final List<String> issueKeys) {
+        this.issueKeys = issueKeys;
     }
 
     @Extension
@@ -189,6 +199,7 @@ public class JiraSendDeploymentInfoStep extends Step implements Serializable {
             final TaskListener taskListener = getContext().get(TaskListener.class);
             final WorkflowRun workflowRun = getContext().get(WorkflowRun.class);
             final Set<String> serviceIds = ImmutableSet.copyOf(step.getServiceIds());
+            final Set<String> issueKeys = ImmutableSet.copyOf(step.getIssueKeys());
 
             final JiraDeploymentInfoRequest request =
                     new JiraDeploymentInfoRequest(
@@ -199,6 +210,7 @@ public class JiraSendDeploymentInfoStep extends Step implements Serializable {
                             step.getState(),
                             serviceIds,
                             step.getEnableGating(),
+                            issueKeys,
                             workflowRun);
             final JiraSendInfoResponse response =
                     JiraSenderFactory.getInstance()

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/JiraDeploymentInfoRequest.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/JiraDeploymentInfoRequest.java
@@ -17,6 +17,7 @@ public class JiraDeploymentInfoRequest {
     private final String state;
     private final Set<String> serviceIds;
     private final Boolean enableGating;
+    private final Set<String> issueKeys;
 
     public JiraDeploymentInfoRequest(
             @Nullable final String site,
@@ -26,6 +27,7 @@ public class JiraDeploymentInfoRequest {
             @Nullable final String state,
             final Set<String> serviceIds,
             final Boolean enableGating,
+            final Set<String> issueKeys,
             final WorkflowRun deployment) {
         this.site = site;
         this.environmentId = environmentId;
@@ -35,6 +37,7 @@ public class JiraDeploymentInfoRequest {
         this.deployment = requireNonNull(deployment);
         this.serviceIds = serviceIds;
         this.enableGating = enableGating;
+        this.issueKeys = issueKeys;
     }
 
     @Nullable
@@ -69,5 +72,9 @@ public class JiraDeploymentInfoRequest {
 
     public Boolean getEnableGating() {
         return enableGating;
+    }
+
+    public Set<String> getIssueKeys() {
+        return issueKeys;
     }
 }

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/JiraDeploymentInfoSenderImpl.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/JiraDeploymentInfoSenderImpl.java
@@ -83,6 +83,7 @@ public class JiraDeploymentInfoSenderImpl implements JiraDeploymentInfoSender {
         final WorkflowRun deployment = request.getDeployment();
         final Set<String> serviceIds = request.getServiceIds();
         final Boolean enableGating = request.getEnableGating();
+        final Set<String> requestIssueKeys = request.getIssueKeys();
 
         final Optional<JiraCloudSiteConfig> maybeSiteConfig = getSiteConfigFor(jiraSite);
 
@@ -113,7 +114,13 @@ public class JiraDeploymentInfoSenderImpl implements JiraDeploymentInfoSender {
             return JiraDeploymentInfoResponse.failureStateInvalid(errorMessages);
         }
 
-        final Set<String> issueKeys = issueKeyExtractor.extractIssueKeys(deployment);
+        final Set<String> issueKeys;
+
+        if (requestIssueKeys.isEmpty()) {
+            issueKeys = issueKeyExtractor.extractIssueKeys(deployment);
+        } else {
+            issueKeys = requestIssueKeys;
+        }
 
         if (issueKeys.isEmpty() && serviceIds.isEmpty()) {
             return JiraDeploymentInfoResponse.skippedIssueKeysNotFoundAndServiceIdsAreEmpty(

--- a/src/main/resources/com/atlassian/jira/cloud/jenkins/deploymentinfo/pipeline/JiraSendDeploymentInfoStep/config.jelly
+++ b/src/main/resources/com/atlassian/jira/cloud/jenkins/deploymentinfo/pipeline/JiraSendDeploymentInfoStep/config.jelly
@@ -19,6 +19,9 @@
     <f:entry field="serviceIds" title="${%ServiceIds}">
         <f:textbox/>
     </f:entry>
+    <f:entry field="issueKeys" title="${%IssueKeys}">
+        <f:textbox/>
+    </f:entry>
     <f:entry field="enableGating" title="${%EnableGating}">
         <f:checkbox/>
     </f:entry>

--- a/src/main/resources/com/atlassian/jira/cloud/jenkins/deploymentinfo/pipeline/JiraSendDeploymentInfoStep/config.properties
+++ b/src/main/resources/com/atlassian/jira/cloud/jenkins/deploymentinfo/pipeline/JiraSendDeploymentInfoStep/config.properties
@@ -4,4 +4,5 @@ EnvironmentName=EnvironmentName
 EnvironmentType=EnvironmentType
 State=State
 ServiceIds=ServiceIds
+IssueKeys=IssueKeys
 EnableGating=EnableGating

--- a/src/main/resources/com/atlassian/jira/cloud/jenkins/deploymentinfo/pipeline/JiraSendDeploymentInfoStep/help.html
+++ b/src/main/resources/com/atlassian/jira/cloud/jenkins/deploymentinfo/pipeline/JiraSendDeploymentInfoStep/help.html
@@ -9,7 +9,7 @@
     Please select the Jira Software Cloud site name you would like to create the pipeline script for. You can only select 1 site at this time. If you want to send information to multiple sites, please create multiple Pipeline Scripts.
     You also need to specify the environment ID, name and type. Valid environment types are 'unmapped', 'development', 'testing', 'staging' and 'production'.
     <br />
-    State and Service Ids are optional parameters. Use state to explicitly describe your deployment state or it will determine from the Jenkins job for you. Valid state values: 'unknown', 'pending', 'in_progress', 'cancelled', 'failed', 'rolled_back', 'successful'
+    State, Service Ids and IssueKeys are optional parameters. Use state to explicitly describe your deployment state or it will determine from the Jenkins job for you. Valid state values: 'unknown', 'pending', 'in_progress', 'cancelled', 'failed', 'rolled_back', 'successful'
     <!--TODO add link to official Change management docs -->
     Service Ids uses to automatically create a change management request for your deployment
 

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/JiraDeploymentInfoSenderImplTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/JiraDeploymentInfoSenderImplTest.java
@@ -33,6 +33,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import static com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse.Status.FAILURE_SECRET_NOT_FOUND;
@@ -186,6 +187,22 @@ public class JiraDeploymentInfoSenderImplTest {
     }
 
     @Test
+    public void testSendDeploymentInfo_whenDeploymentAcceptedWithExternalIssueKeys() {
+        // given
+        setupDeploymentsApiDeploymentAccepted();
+
+        // when
+        final JiraSendInfoResponse response =
+                classUnderTest.sendDeploymentInfo(createRequest(ImmutableSet.of("TEST-123")));
+
+        // then
+        assertThat(response.getStatus())
+                .isEqualTo(JiraSendInfoResponse.Status.SUCCESS_DEPLOYMENT_ACCEPTED);
+        final String message = response.getMessage();
+        assertThat(message).isNotBlank();
+    }
+
+    @Test
     public void testSendDeploymentInfo_whenDeploymentRejected() {
         // given
         setupDeploymentsApiDeploymentRejected();
@@ -283,6 +300,7 @@ public class JiraDeploymentInfoSenderImplTest {
                         "pending",
                         Collections.emptySet(),
                         Boolean.TRUE,
+                        Collections.emptySet(),
                         mockWorkflowRun());
 
         final ArgumentCaptor<Deployments> deploymentsArgumentCaptor =
@@ -317,6 +335,10 @@ public class JiraDeploymentInfoSenderImplTest {
     }
 
     private JiraDeploymentInfoRequest createRequest() {
+        return createRequest(Collections.emptySet());
+    }
+
+    private JiraDeploymentInfoRequest createRequest(final Set<String> issueKeys) {
         return new JiraDeploymentInfoRequest(
                 SITE,
                 ENVIRONMENT_ID,
@@ -325,6 +347,7 @@ public class JiraDeploymentInfoSenderImplTest {
                 null,
                 Collections.emptySet(),
                 Boolean.FALSE,
+                issueKeys,
                 mockWorkflowRun());
     }
 
@@ -337,6 +360,7 @@ public class JiraDeploymentInfoSenderImplTest {
                 state,
                 Collections.emptySet(),
                 Boolean.FALSE,
+                Collections.emptySet(),
                 mockWorkflowRun());
     }
 
@@ -352,6 +376,7 @@ public class JiraDeploymentInfoSenderImplTest {
                 null,
                 Collections.emptySet(),
                 Boolean.FALSE,
+                Collections.emptySet(),
                 mockWorkflowRun());
     }
 

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/JiraDeploymentInfoSenderImplTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/JiraDeploymentInfoSenderImplTest.java
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -196,6 +197,7 @@ public class JiraDeploymentInfoSenderImplTest {
                 classUnderTest.sendDeploymentInfo(createRequest(ImmutableSet.of("TEST-123")));
 
         // then
+        verifyZeroInteractions(issueKeyExtractor);
         assertThat(response.getStatus())
                 .isEqualTo(JiraSendInfoResponse.Status.SUCCESS_DEPLOYMENT_ACCEPTED);
         final String message = response.getMessage();


### PR DESCRIPTION
	Bypass the issue extractor run by proviging your own list of issue
	keys for those cases when the Jenkins changelog does not reflect
	what you want to do.