### PR TITLE
pick issue key from commit title

### DIFF
--- a/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/service/JiraBuildInfoSenderImpl.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/service/JiraBuildInfoSenderImpl.java
@@ -130,7 +130,6 @@ public class JiraBuildInfoSenderImpl implements JiraBuildInfoSender {
                                                 .map(IssueKey::toString)
                                                 .collect(Collectors.toSet()))
                         .orElseGet(() -> issueKeyExtractor.extractIssueKeys(build));
-
         Set<String> CommitIssueKeys = changeLogIssueKeyExtractor.extractIssueKeys(build);
         if (!CommitIssueKeys.isEmpty()) {
             branchIssueKeys.addAll(CommitIssueKeys);

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/service/JiraBuildInfoSenderImpl.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/service/JiraBuildInfoSenderImpl.java
@@ -13,6 +13,7 @@ import com.atlassian.jira.cloud.jenkins.common.response.JiraCommonResponse;
 import com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse;
 import com.atlassian.jira.cloud.jenkins.common.service.IssueKeyExtractor;
 import com.atlassian.jira.cloud.jenkins.config.JiraCloudSiteConfig;
+import com.atlassian.jira.cloud.jenkins.deploymentinfo.service.ChangeLogIssueKeyExtractor;
 import com.atlassian.jira.cloud.jenkins.tenantinfo.CloudIdResolver;
 import com.atlassian.jira.cloud.jenkins.util.IssueKeyStringExtractor;
 import com.atlassian.jira.cloud.jenkins.util.RunWrapperProvider;
@@ -47,6 +48,7 @@ public class JiraBuildInfoSenderImpl implements JiraBuildInfoSender {
     private final AccessTokenRetriever accessTokenRetriever;
     private final JiraApi buildsApi;
     private final RunWrapperProvider runWrapperProvider;
+    private final IssueKeyExtractor changeLogIssueKeyExtractor = new ChangeLogIssueKeyExtractor();
 
     public JiraBuildInfoSenderImpl(
             final JiraSiteConfigRetriever siteConfigRetriever,
@@ -119,14 +121,21 @@ public class JiraBuildInfoSenderImpl implements JiraBuildInfoSender {
     }
 
     private Set<String> getIssueKeys(final JiraBuildInfoRequest request, final WorkflowRun build) {
-        return Optional.ofNullable(request.getBranch())
-                .map(
-                        branch ->
-                                IssueKeyStringExtractor.extractIssueKeys(branch)
-                                        .stream()
-                                        .map(IssueKey::toString)
-                                        .collect(Collectors.toSet()))
-                .orElseGet(() -> issueKeyExtractor.extractIssueKeys(build));
+        Set<String> branchIssueKeys =
+                Optional.ofNullable(request.getBranch())
+                        .map(
+                                branch ->
+                                        IssueKeyStringExtractor.extractIssueKeys(branch)
+                                                .stream()
+                                                .map(IssueKey::toString)
+                                                .collect(Collectors.toSet()))
+                        .orElseGet(() -> issueKeyExtractor.extractIssueKeys(build));
+
+        Set<String> CommitIssueKeys = changeLogIssueKeyExtractor.extractIssueKeys(build);
+        if (!CommitIssueKeys.isEmpty()) {
+            branchIssueKeys.addAll(CommitIssueKeys);
+        }
+        return branchIssueKeys;
     }
 
     private Optional<JiraCloudSiteConfig> getSiteConfigFor(@Nullable final String jiraSite) {


### PR DESCRIPTION
I fixed JENKINS-61185 issue.
made code changes to make Jenkins to pick issueKeys from commit message and to send build info into Jira Issue.
JiraBuildInfoSenderImpl will use ChangeLogIssueKeyExtractor to get issue keys from commit message.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
