### PR TITLE
Extracts changelog keys since last successful build.

### DIFF
--- a/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/ChangeLogIssueKeyExtractor.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/ChangeLogIssueKeyExtractor.java
@@ -12,7 +12,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckForNull;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/ChangeLogIssueKeyExtractor.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/ChangeLogIssueKeyExtractor.java
@@ -3,13 +3,16 @@ package com.atlassian.jira.cloud.jenkins.deploymentinfo.service;
 import com.atlassian.jira.cloud.jenkins.common.model.IssueKey;
 import com.atlassian.jira.cloud.jenkins.common.service.IssueKeyExtractor;
 import com.atlassian.jira.cloud.jenkins.util.IssueKeyStringExtractor;
+import hudson.model.Result;
+import hudson.model.Run;
 import hudson.plugins.git.GitChangeSet;
 import hudson.scm.ChangeLogSet;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import javax.annotation.CheckForNull;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -18,11 +21,21 @@ import java.util.stream.Collectors;
  */
 public final class ChangeLogIssueKeyExtractor implements IssueKeyExtractor {
 
+    private static final Logger log = LoggerFactory.getLogger(ChangeLogIssueKeyExtractor.class);
+
     public Set<String> extractIssueKeys(final WorkflowRun workflowRun) {
 
         final Set<IssueKey> allIssueKeys = new HashSet<>();
         final List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSets =
-                workflowRun.getChangeSets();
+                new ArrayList<>(workflowRun.getChangeSets());
+
+        WorkflowRun previous = workflowRun.getPreviousBuild();
+        while (Objects.nonNull(previous) && !isBuildSuccessful(previous)) {
+            log.info("Extract issue keys from build: " + previous.getNumber());
+
+            changeSets.addAll(previous.getChangeSets());
+            previous = previous.getPreviousBuild();
+        }
 
         for (ChangeLogSet<? extends ChangeLogSet.Entry> changeSet : changeSets) {
             final Object[] changeSetEntries = changeSet.getItems();
@@ -48,5 +61,14 @@ public final class ChangeLogIssueKeyExtractor implements IssueKeyExtractor {
                 .limit(ISSUE_KEY_MAX_LIMIT)
                 .map(IssueKey::toString)
                 .collect(Collectors.toSet());
+    }
+
+    private boolean isBuildSuccessful(@CheckForNull final WorkflowRun workflowRun) {
+
+        return Optional.ofNullable(workflowRun)
+                .map(Run::getResult)
+                .map(Result::toString)
+                .map(Result.SUCCESS.toString()::equals)
+                .orElse(true);
     }
 }

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/ChangeLogIssueKeyExtractorTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/ChangeLogIssueKeyExtractorTest.java
@@ -1,0 +1,77 @@
+package com.atlassian.jira.cloud.jenkins.deploymentinfo.service;
+
+import hudson.model.Result;
+import hudson.scm.ChangeLogSet;
+import junit.framework.TestCase;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Test;
+import org.jvnet.hudson.test.FakeChangeLogSCM.EntryImpl;
+import org.jvnet.hudson.test.FakeChangeLogSCM.FakeChangeLogSet;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.Mockito.*;
+
+public class ChangeLogIssueKeyExtractorTest extends TestCase {
+
+    @Test
+    public void testExtractIssueKeys() {
+
+        WorkflowRun current = mock(WorkflowRun.class);
+        WorkflowRun previous1 = mock(WorkflowRun.class);
+        WorkflowRun previous2 = mock(WorkflowRun.class);
+
+        when(current.getPreviousBuild()).thenReturn(previous1);
+        when(previous1.getPreviousBuild()).thenReturn(previous2);
+        when(previous2.getPreviousBuild()).thenReturn(null);
+
+        EntryImpl e1 = new EntryImpl().withMsg("TEST-1 Some message");
+        EntryImpl e2 = new EntryImpl().withMsg("TEST-2 Another message");
+        EntryImpl e3 = new EntryImpl().withMsg("TEST-3 One more message");
+
+        List<EntryImpl> entryListCurrent = new ArrayList<>();
+        entryListCurrent.add(e1);
+        List<EntryImpl> entryListPrevious1 = new ArrayList<>();
+        entryListPrevious1.add(e2);
+        List<EntryImpl> entryListPrevious2 = new ArrayList<>();
+        entryListPrevious2.add(e3);
+
+        FakeChangeLogSet changeLogSetCurrent =
+                new FakeChangeLogSet(current, entryListCurrent);
+        FakeChangeLogSet changeLogSetPrevious1 =
+                new FakeChangeLogSet(previous1, entryListPrevious1);
+        FakeChangeLogSet changeLogSetPrevious2 =
+                new FakeChangeLogSet(previous2, entryListPrevious2);
+
+        List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSetsCurrent =
+                new ArrayList<>();
+        changeSetsCurrent.add(changeLogSetCurrent);
+
+        List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSetsPrevious1 =
+                new ArrayList<>();
+        changeSetsPrevious1.add(changeLogSetPrevious1);
+
+        List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSetsPrevious2 =
+                new ArrayList<>();
+        changeSetsPrevious2.add(changeLogSetPrevious2);
+
+        when(current.getChangeSets()).thenReturn(changeSetsCurrent);
+        when(previous1.getChangeSets()).thenReturn(changeSetsPrevious1);
+        when(previous2.getChangeSets()).thenReturn(changeSetsPrevious2);
+
+        when(previous1.getResult()).thenReturn(Result.FAILURE);
+        when(previous2.getResult()).thenReturn(Result.SUCCESS);
+
+        ChangeLogIssueKeyExtractor extractor = new ChangeLogIssueKeyExtractor();
+        Set<String> issueKeys = extractor.extractIssueKeys(current);
+
+        verify(previous1).getChangeSets();
+        verify(previous2, never()).getChangeSets();
+
+        assertTrue(issueKeys.contains("TEST-1"));
+        assertTrue(issueKeys.contains("TEST-2"));
+        assertFalse(issueKeys.contains("TEST-3"));
+    }
+}


### PR DESCRIPTION
I implemented improvement that ChangeLogIssueKeyExtractor extracts keys from all changelogs since last successful build.

If is useful if change X fixes build problem of change Y.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
