### PR TITLE
pick branch name from build when branch name is empty in Jenkinsfile

### DIFF
--- a/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/service/JiraBuildInfoSenderImpl.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/service/JiraBuildInfoSenderImpl.java
@@ -19,6 +19,7 @@ import com.atlassian.jira.cloud.jenkins.util.IssueKeyStringExtractor;
 import com.atlassian.jira.cloud.jenkins.util.RunWrapperProvider;
 import com.atlassian.jira.cloud.jenkins.util.SecretRetriever;
 import hudson.model.Run;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
 import org.slf4j.Logger;
@@ -123,6 +124,7 @@ public class JiraBuildInfoSenderImpl implements JiraBuildInfoSender {
     private Set<String> getIssueKeys(final JiraBuildInfoRequest request, final WorkflowRun build) {
         Set<String> branchIssueKeys =
                 Optional.ofNullable(request.getBranch())
+                        .filter(StringUtils::isNotEmpty)
                         .map(
                                 branch ->
                                         IssueKeyStringExtractor.extractIssueKeys(branch)
@@ -130,9 +132,9 @@ public class JiraBuildInfoSenderImpl implements JiraBuildInfoSender {
                                                 .map(IssueKey::toString)
                                                 .collect(Collectors.toSet()))
                         .orElseGet(() -> issueKeyExtractor.extractIssueKeys(build));
-        Set<String> CommitIssueKeys = changeLogIssueKeyExtractor.extractIssueKeys(build);
-        if (!CommitIssueKeys.isEmpty()) {
-            branchIssueKeys.addAll(CommitIssueKeys);
+        Set<String> commitIssueKeys = changeLogIssueKeyExtractor.extractIssueKeys(build);
+        if (!commitIssueKeys.isEmpty()) {
+            branchIssueKeys.addAll(commitIssueKeys);
         }
         return branchIssueKeys;
     }

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/buildinfo/service/JiraBuildInfoSenderImplTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/buildinfo/service/JiraBuildInfoSenderImplTest.java
@@ -193,13 +193,31 @@ public class JiraBuildInfoSenderImplTest {
     @Test
     public void testSendBuildInfo_whenUserProvidedBranch() {
         // given
-        final JiraBuildInfoRequest jiraBuildInfoRequest = new JiraBuildInfoRequest(SITE, BRANCH_NAME, mockWorkflowRun());
+        final JiraBuildInfoRequest jiraBuildInfoRequest =
+                new JiraBuildInfoRequest(SITE, BRANCH_NAME, mockWorkflowRun());
         setupBuildsApiBuildAccepted();
 
         // when
         final JiraSendInfoResponse response = classUnderTest.sendBuildInfo(jiraBuildInfoRequest);
 
         verify(issueKeyExtractor, never()).extractIssueKeys(any());
+        assertThat(response.getStatus())
+                .isEqualTo(JiraSendInfoResponse.Status.SUCCESS_BUILD_ACCEPTED);
+        final String message = response.getMessage();
+        assertThat(message).isNotBlank();
+    }
+
+    @Test
+    public void testSendBuildInfo_whenBranchNameIsEmpty() {
+        // given
+        final JiraBuildInfoRequest jiraBuildInfoRequest =
+                new JiraBuildInfoRequest(SITE, "", mockWorkflowRun());
+        setupBuildsApiBuildAccepted();
+
+        // when
+        final JiraSendInfoResponse response = classUnderTest.sendBuildInfo(jiraBuildInfoRequest);
+
+        verify(issueKeyExtractor).extractIssueKeys(any());
         assertThat(response.getStatus())
                 .isEqualTo(JiraSendInfoResponse.Status.SUCCESS_BUILD_ACCEPTED);
         final String message = response.getMessage();


### PR DESCRIPTION
Currently it is ignoring issue keys from branch name when branch name is empty in Jenkinsfile, 
fixed it by adding empty check for branch name.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
