### PR TITLE
Specify maven compiler java version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
         <archunit.version>0.9.2</archunit.version>
         <resilience4j.version>1.4.0</resilience4j.version>
         <slf4j.version>1.7.26</slf4j.version>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
     </properties>
     <name>Atlassian Jira Software Cloud</name>
     <description>Atlassian Jira Software Cloud Jenkins Integration</description>


### PR DESCRIPTION
Added which version of java maven needs to compile with.  This makes it simpler for contributors to just run maven as it will look for that version on the system and build on it instead of pointing the `java` command to 1.8.  If the version is missing, an error will occur which will say that the version is missing and needs to be installed.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
