### PR TITLE
Fix non-multibranch pipelines crashing

### DIFF
--- a/src/main/java/com/atlassian/jira/cloud/jenkins/util/BranchNameIssueKeyExtractor.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/util/BranchNameIssueKeyExtractor.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.HashSet;
 import java.util.stream.Collectors;
 
 /**
@@ -28,7 +29,7 @@ public class BranchNameIssueKeyExtractor implements IssueKeyExtractor {
 
         if (scmAction == null) {
             logger.debug("SCMRevisionAction is null");
-            return Collections.emptySet();
+            return new HashSet<String>();
         }
 
         final SCMRevision revision = scmAction.getRevision();


### PR DESCRIPTION
It is established that this plugin only supports multibranch pipelines (https://community.atlassian.com/t5/Jira-questions/Jenkins-Plugin-for-Jira-Cloud/qaq-p/1624021).
This pull request doesn't intend to fully support non-multibranch pipelines, but at least avoid them to fail.

Currently, if you run a simple pipeline job with a `jiraSendBuildInfo` post step, you will the following error :
```sh
java.lang.UnsupportedOperationException
	at java.base/java.util.AbstractCollection.add(AbstractCollection.java:267)
	at java.base/java.util.AbstractCollection.addAll(AbstractCollection.java:352)
	at com.atlassian.jira.cloud.jenkins.buildinfo.service.MultibranchBuildInfoSenderImpl.getIssueKeys(MultibranchBuildInfoSenderImpl.java:52)
```
This error happens because when we are not on a multibranch pipeline, the `SCMRevisionAction` is not populated in the `WorkflowRun` (as stated in `BranchNameIssueKeyExtractor` class). In that specific case, the `extractIssueKeys` method returns `Collections.emptySet()` which is an immutable set. 
Since the set is not mutable, the `addAll` method on such a set will throw an UnsupportedOperationException.
That is what is happening in `MultibranchBuildInfoSenderImpl.getIssueKeys` (line 52 of MultibranchBuildInfoSenderImpl.java, as in the error trace).

Instead of returning an immutable set, I believe we should just return an empty (but mutable) set.
This would avoid non-multibranch pipelines to crash when there is an issue key in the commit title.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
