### PR TITLE
Jenkins app client for builds and deployments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <assertj.version>3.11.1</assertj.version>
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
         <archunit.version>0.9.2</archunit.version>
+        <jsonassert.version>1.5.0</jsonassert.version>
         <resilience4j.version>1.4.0</resilience4j.version>
         <slf4j.version>1.7.30</slf4j.version>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -256,6 +257,12 @@
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit4</artifactId>
             <version>${archunit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>${jsonassert.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/client/BuildsApi.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/client/BuildsApi.java
@@ -8,8 +8,6 @@ import com.atlassian.jira.cloud.jenkins.common.client.JenkinsAppRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.OkHttpClient;
 
-import java.time.Instant;
-
 public class BuildsApi extends JenkinsAppApi<BuildApiResponse> {
 
     public BuildsApi(final OkHttpClient httpClient, final ObjectMapper objectMapper) {
@@ -19,11 +17,11 @@ public class BuildsApi extends JenkinsAppApi<BuildApiResponse> {
     /**
      * Sends a build event to the Jenkins app in Jira.
      *
-     * @param webhookUrl URL to the Jenkins app webhook.
+     * @param webhookUrl    URL to the Jenkins app webhook.
      * @param buildsRequest the payload of the builds request.
      * @return the response of the Jenkins app webhook.
      * @throws ApiUpdateFailedException if the webhook responded with a non-successful HTTP status
-     *     code.
+     *                                  code.
      */
     public BuildApiResponse sendBuild(final String webhookUrl, final Builds buildsRequest)
             throws ApiUpdateFailedException {

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/client/BuildsApi.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/client/BuildsApi.java
@@ -1,0 +1,43 @@
+package com.atlassian.jira.cloud.jenkins.buildinfo.client;
+
+import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.BuildApiResponse;
+import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.Builds;
+import com.atlassian.jira.cloud.jenkins.common.client.ApiUpdateFailedException;
+import com.atlassian.jira.cloud.jenkins.common.client.JenkinsAppApi;
+import com.atlassian.jira.cloud.jenkins.common.client.JenkinsAppRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+
+import java.time.Instant;
+
+public class BuildsApi extends JenkinsAppApi<BuildApiResponse> {
+
+    public BuildsApi(final OkHttpClient httpClient, final ObjectMapper objectMapper) {
+        super(httpClient, objectMapper);
+    }
+
+    /**
+     * Sends a build event to the Jenkins app in Jira.
+     *
+     * @param webhookUrl URL to the Jenkins app webhook.
+     * @param buildsRequest the payload of the builds request.
+     * @return the response of the Jenkins app webhook.
+     * @throws ApiUpdateFailedException if the webhook responded with a non-successful HTTP status
+     *     code.
+     */
+    public BuildApiResponse sendBuild(final String webhookUrl, final Builds buildsRequest)
+            throws ApiUpdateFailedException {
+
+        JenkinsAppRequest request =
+                new JenkinsAppRequest(
+                        JenkinsAppRequest.RequestType.EVENT,
+                        JenkinsAppRequest.EventType.BUILD,
+                        buildsRequest.getBuild().getPipelineId(),
+                        buildsRequest.getBuild().getDisplayName(),
+                        buildsRequest.getBuild().getState(),
+                        buildsRequest.getBuild().getLastUpdated(),
+                        buildsRequest);
+
+        return this.sendRequest(webhookUrl, request, BuildApiResponse.class);
+    }
+}

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/client/model/Builds.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/client/model/Builds.java
@@ -3,24 +3,31 @@ package com.atlassian.jira.cloud.jenkins.buildinfo.client.model;
 import com.atlassian.jira.cloud.jenkins.common.client.JiraRequest;
 import com.atlassian.jira.cloud.jenkins.common.client.model.Properties;
 import com.atlassian.jira.cloud.jenkins.common.client.model.ProviderMetadata;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Collections;
 import java.util.List;
 
 /** This represents the payload for the API request to submit list of builds */
 public class Builds implements JiraRequest {
-    private List<JiraBuildInfo> builds;
+    @JsonIgnore private JiraBuildInfo build;
     private Properties properties;
     private ProviderMetadata providerMetadata;
 
     public Builds(final JiraBuildInfo jiraBuildInfo) {
-        this.builds = Collections.singletonList(jiraBuildInfo);
+        this.build = jiraBuildInfo;
         this.properties = new Properties();
         this.providerMetadata = new ProviderMetadata();
     }
 
+    public JiraBuildInfo getBuild() {
+        return build;
+    }
+
+    @JsonProperty("builds")
     public List<JiraBuildInfo> getBuilds() {
-        return builds;
+        return Collections.singletonList(build);
     }
 
     public Properties getProperties() {

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/service/FreestyleJiraBuildInfoSenderImpl.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/service/FreestyleJiraBuildInfoSenderImpl.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.atlassian.jira.cloud.jenkins.buildinfo.client.BuildsApi;
+import com.atlassian.jira.cloud.jenkins.common.config.JiraSiteConfig2Retriever;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
 
@@ -27,21 +29,14 @@ public class FreestyleJiraBuildInfoSenderImpl extends JiraBuildInfoSenderImpl {
     private final FreestyleIssueKeyExtractor changeLogIssueKeyExtractor;
 
     public FreestyleJiraBuildInfoSenderImpl(
-            final JiraSiteConfigRetriever siteConfigRetriever,
+            final JiraSiteConfig2Retriever siteConfigRetriever,
             final SecretRetriever secretRetriever,
             final FreestyleIssueKeyExtractor issueKeyExtractor,
             final CloudIdResolver cloudIdResolver,
-            final AccessTokenRetriever accessTokenRetriever,
-            final JiraApi buildsApi,
+            final BuildsApi buildsApi,
             final RunWrapperProvider runWrapperProvider,
             final FreestyleIssueKeyExtractor changeLogIssueKeyExtractor) {
-        super(
-                siteConfigRetriever,
-                secretRetriever,
-                cloudIdResolver,
-                accessTokenRetriever,
-                buildsApi,
-                runWrapperProvider);
+        super(siteConfigRetriever, secretRetriever, cloudIdResolver, buildsApi, runWrapperProvider);
         this.issueKeyExtractor = requireNonNull(issueKeyExtractor);
         this.changeLogIssueKeyExtractor = requireNonNull(changeLogIssueKeyExtractor);
     }

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/service/JiraBuildInfoSenderImpl.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/service/JiraBuildInfoSenderImpl.java
@@ -1,32 +1,26 @@
 package com.atlassian.jira.cloud.jenkins.buildinfo.service;
 
-import static java.util.Objects.requireNonNull;
+import com.atlassian.jira.cloud.jenkins.buildinfo.client.BuildsApi;
+import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.BuildApiResponse;
+import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.Builds;
+import com.atlassian.jira.cloud.jenkins.common.client.ApiUpdateFailedException;
+import com.atlassian.jira.cloud.jenkins.common.config.JiraSiteConfig2Retriever;
+import com.atlassian.jira.cloud.jenkins.common.response.JiraCommonResponse;
+import com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse;
+import com.atlassian.jira.cloud.jenkins.config.JiraCloudSiteConfig2;
+import com.atlassian.jira.cloud.jenkins.tenantinfo.CloudIdResolver;
+import com.atlassian.jira.cloud.jenkins.util.Constants;
+import com.atlassian.jira.cloud.jenkins.util.RunWrapperProvider;
+import com.atlassian.jira.cloud.jenkins.util.SecretRetriever;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.atlassian.jira.cloud.jenkins.auth.AccessTokenRetriever;
-import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.BuildApiResponse;
-import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.Builds;
-import com.atlassian.jira.cloud.jenkins.common.client.JiraApi;
-import com.atlassian.jira.cloud.jenkins.common.client.PostUpdateResult;
-import com.atlassian.jira.cloud.jenkins.common.config.JiraSiteConfigRetriever;
-import com.atlassian.jira.cloud.jenkins.common.model.AppCredential;
-import com.atlassian.jira.cloud.jenkins.common.response.JiraCommonResponse;
-import com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse;
-import com.atlassian.jira.cloud.jenkins.config.JiraCloudSiteConfig;
-import com.atlassian.jira.cloud.jenkins.tenantinfo.CloudIdResolver;
-import com.atlassian.jira.cloud.jenkins.util.Constants;
-import com.atlassian.jira.cloud.jenkins.util.RunWrapperProvider;
-import com.atlassian.jira.cloud.jenkins.util.SecretRetriever;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Implementation of JiraBuildInfoSender to send build updates to Jira by building the payload,
@@ -34,27 +28,22 @@ import com.atlassian.jira.cloud.jenkins.util.SecretRetriever;
  */
 public abstract class JiraBuildInfoSenderImpl implements JiraBuildInfoSender {
 
-    private static final Logger log = LoggerFactory.getLogger(JiraBuildInfoSenderImpl.class);
-
-    private final JiraSiteConfigRetriever siteConfigRetriever;
+    private final JiraSiteConfig2Retriever siteConfigRetriever;
     private final SecretRetriever secretRetriever;
 
     private final CloudIdResolver cloudIdResolver;
-    private final AccessTokenRetriever accessTokenRetriever;
-    private final JiraApi buildsApi;
+    private final BuildsApi buildsApi;
     protected final RunWrapperProvider runWrapperProvider;
 
     public JiraBuildInfoSenderImpl(
-            final JiraSiteConfigRetriever siteConfigRetriever,
+            final JiraSiteConfig2Retriever siteConfigRetriever,
             final SecretRetriever secretRetriever,
             final CloudIdResolver cloudIdResolver,
-            final AccessTokenRetriever accessTokenRetriever,
-            final JiraApi buildsApi,
+            final BuildsApi buildsApi,
             final RunWrapperProvider runWrapperProvider) {
         this.siteConfigRetriever = requireNonNull(siteConfigRetriever);
         this.secretRetriever = requireNonNull(secretRetriever);
         this.cloudIdResolver = requireNonNull(cloudIdResolver);
-        this.accessTokenRetriever = requireNonNull(accessTokenRetriever);
         this.buildsApi = requireNonNull(buildsApi);
         this.runWrapperProvider = requireNonNull(runWrapperProvider);
     }
@@ -65,7 +54,7 @@ public abstract class JiraBuildInfoSenderImpl implements JiraBuildInfoSender {
         if (request.getSite() == null) {
             List<String> jiraSites = siteConfigRetriever.getAllJiraSites();
             for (final String jiraSite : jiraSites) {
-                final Optional<JiraCloudSiteConfig> maybeSiteConfig = getSiteConfigFor(jiraSite);
+                final Optional<JiraCloudSiteConfig2> maybeSiteConfig = getSiteConfigFor(jiraSite);
 
                 responses.add(
                         maybeSiteConfig
@@ -73,7 +62,7 @@ public abstract class JiraBuildInfoSenderImpl implements JiraBuildInfoSender {
                                 .orElse(JiraCommonResponse.failureSiteConfigNotFound(jiraSite)));
             }
         } else {
-            final Optional<JiraCloudSiteConfig> maybeSiteConfig =
+            final Optional<JiraCloudSiteConfig2> maybeSiteConfig =
                     getSiteConfigFor(request.getSite());
             responses.add(
                     maybeSiteConfig
@@ -92,15 +81,15 @@ public abstract class JiraBuildInfoSenderImpl implements JiraBuildInfoSender {
      * @param request - JiraBuildInfoRequest::site is ignored and jiraSite is used instead
      */
     public JiraSendInfoResponse sendBuildInfoToJiraSite(
-            @Nonnull final JiraCloudSiteConfig siteConfig,
+            @Nonnull final JiraCloudSiteConfig2 siteConfig,
             @Nonnull final JiraBuildInfoRequest request) {
 
-        final String resolvedSiteConfig = siteConfig.getSite();
+        final String jiraSite = siteConfig.getSite();
 
         final Optional<String> maybeSecret = getSecretFor(siteConfig.getCredentialsId());
 
         if (!maybeSecret.isPresent()) {
-            return JiraCommonResponse.failureSecretNotFound(resolvedSiteConfig);
+            return JiraCommonResponse.failureSecretNotFound(jiraSite);
         }
 
         final Set<String> issueKeys = getIssueKeys(request);
@@ -109,36 +98,25 @@ public abstract class JiraBuildInfoSenderImpl implements JiraBuildInfoSender {
             return JiraBuildInfoResponse.skippedIssueKeysNotFound(siteConfig.getSite());
         }
 
-        final Optional<String> maybeCloudId = getCloudIdFor(resolvedSiteConfig);
+        final Optional<String> maybeCloudId = getCloudIdFor(jiraSite);
 
         if (!maybeCloudId.isPresent()) {
-            return JiraCommonResponse.failureSiteNotFound(resolvedSiteConfig);
-        }
-
-        final Optional<String> maybeAccessToken = getAccessTokenFor(siteConfig, maybeSecret.get());
-
-        if (!maybeAccessToken.isPresent()) {
-            return JiraCommonResponse.failureAccessToken(resolvedSiteConfig);
+            return JiraCommonResponse.failureSiteNotFound(jiraSite);
         }
 
         final Builds buildInfo = createJiraBuildInfo(request, issueKeys);
 
-        final PostUpdateResult<BuildApiResponse> postUpdateResult =
-                sendBuildInfo(
-                        maybeCloudId.get(), maybeAccessToken.get(), resolvedSiteConfig, buildInfo);
-
-        if (postUpdateResult.getResponseEntity().isPresent()) {
+        try {
             return handleBuildApiResponse(
-                    resolvedSiteConfig, postUpdateResult.getResponseEntity().get());
-        } else {
-            final String errorMessage = postUpdateResult.getErrorMessage().orElse("");
-            return handleBuildApiError(resolvedSiteConfig, errorMessage);
+                    jiraSite, buildsApi.sendBuild(siteConfig.getWebhookUrl(), buildInfo));
+        } catch (ApiUpdateFailedException e) {
+            return handleBuildApiError(jiraSite, e.getMessage());
         }
     }
 
     protected abstract Set<String> getIssueKeys(final JiraBuildInfoRequest request);
 
-    private Optional<JiraCloudSiteConfig> getSiteConfigFor(@Nullable final String jiraSite) {
+    private Optional<JiraCloudSiteConfig2> getSiteConfigFor(@Nullable final String jiraSite) {
         return siteConfigRetriever.getJiraSiteConfig(jiraSite);
     }
 
@@ -147,27 +125,12 @@ public abstract class JiraBuildInfoSenderImpl implements JiraBuildInfoSender {
         return cloudIdResolver.getCloudId(jiraSiteUrl);
     }
 
-    private Optional<String> getAccessTokenFor(
-            final JiraCloudSiteConfig siteConfig, final String secret) {
-        final AppCredential appCredential = new AppCredential(siteConfig.getClientId(), secret);
-        return accessTokenRetriever.getAccessToken(appCredential);
-    }
-
     private Optional<String> getSecretFor(final String credentialsId) {
         return secretRetriever.getSecretFor(credentialsId);
     }
 
     protected abstract Builds createJiraBuildInfo(
             final JiraBuildInfoRequest request, final Set<String> issueKeys);
-
-    private PostUpdateResult<BuildApiResponse> sendBuildInfo(
-            final String cloudId,
-            final String accessToken,
-            final String jiraSite,
-            final Builds buildInfo) {
-        return buildsApi.postUpdate(
-                cloudId, accessToken, jiraSite, buildInfo, BuildApiResponse.class);
-    }
 
     private JiraBuildInfoResponse handleBuildApiResponse(
             final String jiraSite, final BuildApiResponse response) {

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/service/MultibranchBuildInfoSenderImpl.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/buildinfo/service/MultibranchBuildInfoSenderImpl.java
@@ -1,10 +1,9 @@
 package com.atlassian.jira.cloud.jenkins.buildinfo.service;
 
-import com.atlassian.jira.cloud.jenkins.auth.AccessTokenRetriever;
 import com.atlassian.jira.cloud.jenkins.buildinfo.client.BuildPayloadBuilder;
+import com.atlassian.jira.cloud.jenkins.buildinfo.client.BuildsApi;
 import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.Builds;
-import com.atlassian.jira.cloud.jenkins.common.client.JiraApi;
-import com.atlassian.jira.cloud.jenkins.common.config.JiraSiteConfigRetriever;
+import com.atlassian.jira.cloud.jenkins.common.config.JiraSiteConfig2Retriever;
 import com.atlassian.jira.cloud.jenkins.common.model.IssueKey;
 import com.atlassian.jira.cloud.jenkins.common.service.IssueKeyExtractor;
 import com.atlassian.jira.cloud.jenkins.deploymentinfo.service.ChangeLogIssueKeyExtractor;
@@ -25,20 +24,13 @@ public class MultibranchBuildInfoSenderImpl extends JiraBuildInfoSenderImpl {
     private final IssueKeyExtractor issueKeyExtractor;
 
     public MultibranchBuildInfoSenderImpl(
-            final JiraSiteConfigRetriever siteConfigRetriever,
+            final JiraSiteConfig2Retriever siteConfigRetriever,
             final SecretRetriever secretRetriever,
             final IssueKeyExtractor issueKeyExtractor,
             final CloudIdResolver cloudIdResolver,
-            final AccessTokenRetriever accessTokenRetriever,
-            final JiraApi buildsApi,
+            final BuildsApi buildsApi,
             final RunWrapperProvider runWrapperProvider) {
-        super(
-                siteConfigRetriever,
-                secretRetriever,
-                cloudIdResolver,
-                accessTokenRetriever,
-                buildsApi,
-                runWrapperProvider);
+        super(siteConfigRetriever, secretRetriever, cloudIdResolver, buildsApi, runWrapperProvider);
         this.issueKeyExtractor = issueKeyExtractor;
     }
 

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/common/client/JenkinsAppApi.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/common/client/JenkinsAppApi.java
@@ -1,0 +1,104 @@
+package com.atlassian.jira.cloud.jenkins.common.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.util.Objects;
+
+public abstract class JenkinsAppApi<ResponseEntity> {
+
+    private static final Logger log = LoggerFactory.getLogger(JenkinsAppApi.class);
+    private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+
+    private final OkHttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public JenkinsAppApi(final OkHttpClient httpClient, final ObjectMapper objectMapper) {
+        this.httpClient = Objects.requireNonNull(httpClient);
+        this.objectMapper = Objects.requireNonNull(objectMapper);
+    }
+
+    protected ResponseEntity sendRequest(
+            final String webhookUrl,
+            final JenkinsAppRequest jenkinsAppRequest,
+            final Class<ResponseEntity> responseClass)
+            throws ApiUpdateFailedException {
+        try {
+            final String requestPayload = objectMapper.writeValueAsString(jenkinsAppRequest);
+            final Request request = createRequest(webhookUrl, requestPayload);
+            final Response response = httpClient.newCall(request).execute();
+
+            checkForErrorResponse(response);
+
+            return handleResponseBody(response, responseClass);
+        } catch (NotSerializableException e) {
+            throw new ApiUpdateFailedException(
+                    String.format("Invalid JSON payload: %s", e.getMessage()));
+        } catch (JsonProcessingException e) {
+            throw new ApiUpdateFailedException(
+                    String.format("Unable to create the request payload: %s", e.getMessage()));
+        } catch (IOException e) {
+            throw new ApiUpdateFailedException(
+                    String.format(
+                            "Server exception when submitting update to Jenkins app in Jira: %s",
+                            e.getMessage()));
+        } catch (RequestNotPermitted e) {
+            throw new ApiUpdateFailedException("Rate limit reached " + e.getMessage());
+        } catch (Exception e) {
+            throw new ApiUpdateFailedException(
+                    String.format(
+                            "Unexpected error when submitting update to Jira: %s", e.getMessage()));
+        }
+    }
+
+    private Request createRequest(final String webhookUrl, final String requestPayload) {
+        RequestBody body = RequestBody.create(JSON, requestPayload);
+        return new Request.Builder().url(webhookUrl).post(body).build();
+    }
+
+    private void checkForErrorResponse(final Response response) throws IOException {
+        if (!response.isSuccessful()) {
+            final String message =
+                    String.format(
+                            "Error response code %d when submitting update to Jenkins app in Jira",
+                            response.code());
+            final ResponseBody responseBody = response.body();
+            if (responseBody != null) {
+                log.error(
+                        String.format(
+                                "Error response body when submitting update to Jenkins app in Jira: %s",
+                                responseBody.string()));
+                responseBody.close();
+            }
+
+            throw new ApiUpdateFailedException(message);
+        }
+    }
+
+    private ResponseEntity handleResponseBody(
+            final Response response, final Class<ResponseEntity> responseClass) throws IOException {
+        ResponseBody body = response.body();
+        if (body == null) {
+            final String message =
+                    "Empty response body when submitting update to Jenkins app in Jira";
+
+            throw new ApiUpdateFailedException(message);
+        }
+
+        return objectMapper.readValue(
+                body.bytes(), objectMapper.getTypeFactory().constructType(responseClass));
+    }
+}

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/common/client/JenkinsAppRequest.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/common/client/JenkinsAppRequest.java
@@ -1,0 +1,92 @@
+package com.atlassian.jira.cloud.jenkins.common.client;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.LocalDateTime;
+
+public class JenkinsAppRequest {
+
+    private final RequestType requestType;
+    private final EventType eventType;
+    private final String pipelineName;
+    private final String status;
+    private final String lastUpdated;
+    private final JiraRequest payload;
+    private final String pipelineId;
+
+    public JenkinsAppRequest(
+            final RequestType requestType,
+            final EventType eventType,
+            final String pipelineId,
+            final String pipelineName,
+            final String status,
+            final String lastUpdated,
+            final JiraRequest payload) {
+        this.requestType = requestType;
+        this.eventType = eventType;
+        this.pipelineId = pipelineId;
+        this.pipelineName = pipelineName;
+        this.status = status;
+        this.lastUpdated = lastUpdated;
+        this.payload = payload;
+    }
+
+    public RequestType getRequestType() {
+        return requestType;
+    }
+
+    public EventType getEventType() {
+        return eventType;
+    }
+
+    public String getPipelineName() {
+        return pipelineName;
+    }
+
+    public String getPipelineId() {
+        return pipelineId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getLastUpdated() {
+        return lastUpdated;
+    }
+
+    public JiraRequest getPayload() {
+        return payload;
+    }
+
+    public enum RequestType {
+        EVENT("event");
+
+        private final String value;
+
+        RequestType(final String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String getValue() {
+            return value;
+        }
+    }
+
+    public enum EventType {
+        BUILD("build"),
+        DEPLOYMENT("deployment");
+
+        private final String value;
+
+        EventType(final String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/common/factory/JiraSenderFactory.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/common/factory/JiraSenderFactory.java
@@ -4,7 +4,6 @@ import com.atlassian.jira.cloud.jenkins.auth.AccessTokenRetriever;
 import com.atlassian.jira.cloud.jenkins.buildinfo.client.BuildsApi;
 import com.atlassian.jira.cloud.jenkins.buildinfo.service.FreestyleJiraBuildInfoSenderImpl;
 import com.atlassian.jira.cloud.jenkins.buildinfo.service.JiraBuildInfoSender;
-import com.atlassian.jira.cloud.jenkins.buildinfo.service.JiraBuildInfoSenderImpl;
 import com.atlassian.jira.cloud.jenkins.buildinfo.service.MultibranchBuildInfoSenderImpl;
 import com.atlassian.jira.cloud.jenkins.checkgatingstatus.service.JiraGatingStatusRetriever;
 import com.atlassian.jira.cloud.jenkins.checkgatingstatus.service.JiraGatingStatusRetrieverImpl;
@@ -15,6 +14,7 @@ import com.atlassian.jira.cloud.jenkins.common.config.JiraSiteConfigRetriever;
 import com.atlassian.jira.cloud.jenkins.common.config.JiraSiteConfigRetrieverImpl;
 import com.atlassian.jira.cloud.jenkins.common.service.FreestyleIssueKeyExtractor;
 import com.atlassian.jira.cloud.jenkins.common.service.IssueKeyExtractor;
+import com.atlassian.jira.cloud.jenkins.deploymentinfo.client.DeploymentsApi;
 import com.atlassian.jira.cloud.jenkins.deploymentinfo.service.ChangeLogIssueKeyExtractor;
 import com.atlassian.jira.cloud.jenkins.deploymentinfo.service.FreestyleChangeLogIssueKeyExtractor;
 import com.atlassian.jira.cloud.jenkins.deploymentinfo.service.JiraDeploymentInfoSender;
@@ -22,9 +22,9 @@ import com.atlassian.jira.cloud.jenkins.deploymentinfo.service.JiraDeploymentInf
 import com.atlassian.jira.cloud.jenkins.provider.HttpClientProvider;
 import com.atlassian.jira.cloud.jenkins.provider.ObjectMapperProvider;
 import com.atlassian.jira.cloud.jenkins.tenantinfo.CloudIdResolver;
-import com.atlassian.jira.cloud.jenkins.util.RunWrapperProviderImpl;
 import com.atlassian.jira.cloud.jenkins.util.BranchNameIssueKeyExtractor;
 import com.atlassian.jira.cloud.jenkins.util.FreestyleBranchNameIssueKeyExtractor;
+import com.atlassian.jira.cloud.jenkins.util.RunWrapperProviderImpl;
 import com.atlassian.jira.cloud.jenkins.util.SecretRetriever;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
@@ -61,11 +61,7 @@ public final class JiraSenderFactory {
         final AccessTokenRetriever accessTokenRetriever =
                 new AccessTokenRetriever(httpClient, objectMapper);
         final BuildsApi buildsApi = new BuildsApi(httpClient, objectMapper);
-        final JiraApi deploymentsApi =
-                new JiraApi(
-                        httpClient,
-                        objectMapper,
-                        ATLASSIAN_API_URL + "/jira/deployments/0.1/cloud/%s/bulk");
+        final DeploymentsApi deploymentsApi = new DeploymentsApi(httpClient, objectMapper);
 
         final JiraApi gateApi =
                 new JiraApi(
@@ -100,10 +96,9 @@ public final class JiraSenderFactory {
 
         this.jiraDeploymentInfoSender =
                 new JiraDeploymentInfoSenderImpl(
-                        siteConfigRetriever,
+                        siteConfig2Retriever,
                         secretRetriever,
                         cloudIdResolver,
-                        accessTokenRetriever,
                         deploymentsApi,
                         changeLogIssueKeyExtractor,
                         new RunWrapperProviderImpl());

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/common/factory/JiraSenderFactory.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/common/factory/JiraSenderFactory.java
@@ -1,6 +1,7 @@
 package com.atlassian.jira.cloud.jenkins.common.factory;
 
 import com.atlassian.jira.cloud.jenkins.auth.AccessTokenRetriever;
+import com.atlassian.jira.cloud.jenkins.buildinfo.client.BuildsApi;
 import com.atlassian.jira.cloud.jenkins.buildinfo.service.FreestyleJiraBuildInfoSenderImpl;
 import com.atlassian.jira.cloud.jenkins.buildinfo.service.JiraBuildInfoSender;
 import com.atlassian.jira.cloud.jenkins.buildinfo.service.JiraBuildInfoSenderImpl;
@@ -8,6 +9,8 @@ import com.atlassian.jira.cloud.jenkins.buildinfo.service.MultibranchBuildInfoSe
 import com.atlassian.jira.cloud.jenkins.checkgatingstatus.service.JiraGatingStatusRetriever;
 import com.atlassian.jira.cloud.jenkins.checkgatingstatus.service.JiraGatingStatusRetrieverImpl;
 import com.atlassian.jira.cloud.jenkins.common.client.JiraApi;
+import com.atlassian.jira.cloud.jenkins.common.config.JiraSiteConfig2Retriever;
+import com.atlassian.jira.cloud.jenkins.common.config.JiraSiteConfig2RetrieverImpl;
 import com.atlassian.jira.cloud.jenkins.common.config.JiraSiteConfigRetriever;
 import com.atlassian.jira.cloud.jenkins.common.config.JiraSiteConfigRetrieverImpl;
 import com.atlassian.jira.cloud.jenkins.common.service.FreestyleIssueKeyExtractor;
@@ -45,6 +48,7 @@ public final class JiraSenderFactory {
         final ObjectMapper objectMapper = objectMapperProvider.objectMapper();
 
         final JiraSiteConfigRetriever siteConfigRetriever = new JiraSiteConfigRetrieverImpl();
+        final JiraSiteConfig2Retriever siteConfig2Retriever = new JiraSiteConfig2RetrieverImpl();
         final BranchNameIssueKeyExtractor branchNameIssueKeyExtractor =
                 new BranchNameIssueKeyExtractor();
         final FreestyleIssueKeyExtractor freestyleBranchNameIssueKeyExtractor =
@@ -56,11 +60,7 @@ public final class JiraSenderFactory {
         final CloudIdResolver cloudIdResolver = new CloudIdResolver(httpClient, objectMapper);
         final AccessTokenRetriever accessTokenRetriever =
                 new AccessTokenRetriever(httpClient, objectMapper);
-        final JiraApi buildsApi =
-                new JiraApi(
-                        httpClient,
-                        objectMapper,
-                        ATLASSIAN_API_URL + "/jira/builds/0.1/cloud/%s/bulk");
+        final BuildsApi buildsApi = new BuildsApi(httpClient, objectMapper);
         final JiraApi deploymentsApi =
                 new JiraApi(
                         httpClient,
@@ -81,20 +81,19 @@ public final class JiraSenderFactory {
 
         this.jiraBuildInfoSender =
                 new MultibranchBuildInfoSenderImpl(
-                        siteConfigRetriever,
+                        siteConfig2Retriever,
                         secretRetriever,
                         branchNameIssueKeyExtractor,
                         cloudIdResolver,
-                        accessTokenRetriever,
                         buildsApi,
                         new RunWrapperProviderImpl());
+
         this.freestyleBuildInfoSender =
                 new FreestyleJiraBuildInfoSenderImpl(
-                        siteConfigRetriever,
+                        siteConfig2Retriever,
                         secretRetriever,
                         freestyleBranchNameIssueKeyExtractor,
                         cloudIdResolver,
-                        accessTokenRetriever,
                         buildsApi,
                         new RunWrapperProviderImpl(),
                         freestyleChangeLogIssueKeyExtractor);

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/client/DeploymentsApi.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/client/DeploymentsApi.java
@@ -1,0 +1,42 @@
+package com.atlassian.jira.cloud.jenkins.deploymentinfo.client;
+
+import com.atlassian.jira.cloud.jenkins.common.client.ApiUpdateFailedException;
+import com.atlassian.jira.cloud.jenkins.common.client.JenkinsAppApi;
+import com.atlassian.jira.cloud.jenkins.common.client.JenkinsAppRequest;
+import com.atlassian.jira.cloud.jenkins.deploymentinfo.client.model.DeploymentApiResponse;
+import com.atlassian.jira.cloud.jenkins.deploymentinfo.client.model.Deployments;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+
+public class DeploymentsApi extends JenkinsAppApi<DeploymentApiResponse> {
+
+    public DeploymentsApi(final OkHttpClient httpClient, final ObjectMapper objectMapper) {
+        super(httpClient, objectMapper);
+    }
+
+    /**
+     * Sends a build event to the Jenkins app in Jira.
+     *
+     * @param webhookUrl         URL to the Jenkins app webhook.
+     * @param deploymentsRequest the payload of the builds request.
+     * @return the response of the Jenkins app webhook.
+     * @throws ApiUpdateFailedException if the webhook responded with a non-successful HTTP status
+     *                                  code.
+     */
+    public DeploymentApiResponse sendDeployment(
+            final String webhookUrl, final Deployments deploymentsRequest)
+            throws ApiUpdateFailedException {
+
+        JenkinsAppRequest request =
+                new JenkinsAppRequest(
+                        JenkinsAppRequest.RequestType.EVENT,
+                        JenkinsAppRequest.EventType.DEPLOYMENT,
+                        deploymentsRequest.getDeployment().getPipeline().getId(),
+                        deploymentsRequest.getDeployment().getDisplayName(),
+                        deploymentsRequest.getDeployment().getState(),
+                        deploymentsRequest.getDeployment().getLastUpdated(),
+                        deploymentsRequest);
+
+        return this.sendRequest(webhookUrl, request, DeploymentApiResponse.class);
+    }
+}

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/client/model/Deployments.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/client/model/Deployments.java
@@ -3,24 +3,34 @@ package com.atlassian.jira.cloud.jenkins.deploymentinfo.client.model;
 import com.atlassian.jira.cloud.jenkins.common.client.JiraRequest;
 import com.atlassian.jira.cloud.jenkins.common.client.model.Properties;
 import com.atlassian.jira.cloud.jenkins.common.client.model.ProviderMetadata;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Collections;
 import java.util.List;
 
-/** This represents the payload for the API request to submit list of deployments */
+/**
+ * This represents the payload for the API request to submit list of deployments
+ */
 public class Deployments implements JiraRequest {
-    private List<JiraDeploymentInfo> deployments;
+    @JsonIgnore
+    private JiraDeploymentInfo deployment;
     private Properties properties;
     private ProviderMetadata providerMetadata;
 
     public Deployments(final JiraDeploymentInfo jiraDeploymentInfo) {
-        this.deployments = Collections.singletonList(jiraDeploymentInfo);
+        this.deployment = jiraDeploymentInfo;
         this.properties = new Properties();
         this.providerMetadata = new ProviderMetadata();
     }
 
+    public JiraDeploymentInfo getDeployment() {
+        return deployment;
+    }
+
+    @JsonProperty("deployments")
     public List<JiraDeploymentInfo> getDeployments() {
-        return deployments;
+        return Collections.singletonList(deployment);
     }
 
     public Properties getProperties() {

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/buildinfo/client/BuildPayloadBuilderTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/buildinfo/client/BuildPayloadBuilderTest.java
@@ -31,7 +31,7 @@ public class BuildPayloadBuilderTest extends BaseUnitTest {
                 BuildPayloadBuilder.getBuildPayload(
                         request.getJiraState(), runWrapper, ImmutableSet.of(ISSUE_KEY));
 
-        final JiraBuildInfo buildInfo = buildPayload.getBuilds().get(0);
+        final JiraBuildInfo buildInfo = buildPayload.getBuild();
         // then
         assertThat(buildPayload.getProviderMetadata().getProduct()).isEqualTo("jenkins");
         assertThat(buildInfo.getPipelineId()).isEqualTo(runWrapper.getFullProjectName());
@@ -58,7 +58,7 @@ public class BuildPayloadBuilderTest extends BaseUnitTest {
                 BuildPayloadBuilder.getBuildPayload(
                         request.getJiraState(), runWrapper, ImmutableSet.of(ISSUE_KEY));
 
-        final JiraBuildInfo buildInfo = buildPayload.getBuilds().get(0);
+        final JiraBuildInfo buildInfo = buildPayload.getBuild();
 
         // then
         assertThat(buildPayload.getProviderMetadata().getProduct()).isEqualTo("jenkins");

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/buildinfo/service/FreestyleJiraBuildInfoSenderImplTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/buildinfo/service/FreestyleJiraBuildInfoSenderImplTest.java
@@ -1,40 +1,15 @@
 package com.atlassian.jira.cloud.jenkins.buildinfo.service;
 
-import static com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse.Status.FAILURE_SECRET_NOT_FOUND;
-import static com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse.Status.FAILURE_SITE_CONFIG_NOT_FOUND;
-import static com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse.Status.FAILURE_SITE_NOT_FOUND;
-import static com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse.Status.SKIPPED_ISSUE_KEYS_NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.Collections;
-import java.util.Optional;
-import java.util.UUID;
-
-import hudson.model.Result;
-import hudson.model.Run;
-import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import com.atlassian.jira.cloud.jenkins.auth.AccessTokenRetriever;
+import com.atlassian.jira.cloud.jenkins.buildinfo.client.BuildsApi;
 import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.BuildApiResponse;
 import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.BuildKeyResponse;
 import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.RejectedBuildResponse;
-import com.atlassian.jira.cloud.jenkins.common.client.JiraApi;
-import com.atlassian.jira.cloud.jenkins.common.client.PostUpdateResult;
-import com.atlassian.jira.cloud.jenkins.common.config.JiraSiteConfigRetriever;
+import com.atlassian.jira.cloud.jenkins.common.client.ApiUpdateFailedException;
+import com.atlassian.jira.cloud.jenkins.common.config.JiraSiteConfig2Retriever;
 import com.atlassian.jira.cloud.jenkins.common.model.ApiErrorResponse;
 import com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse;
 import com.atlassian.jira.cloud.jenkins.common.service.FreestyleIssueKeyExtractor;
-import com.atlassian.jira.cloud.jenkins.config.JiraCloudSiteConfig;
+import com.atlassian.jira.cloud.jenkins.config.JiraCloudSiteConfig2;
 import com.atlassian.jira.cloud.jenkins.deploymentinfo.service.FreestyleChangeLogIssueKeyExtractor;
 import com.atlassian.jira.cloud.jenkins.tenantinfo.CloudIdResolver;
 import com.atlassian.jira.cloud.jenkins.util.FreestyleBranchNameIssueKeyExtractor;
@@ -42,10 +17,25 @@ import com.atlassian.jira.cloud.jenkins.util.RunWrapperProvider;
 import com.atlassian.jira.cloud.jenkins.util.SecretRetriever;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
 import hudson.AbortException;
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.scm.ChangeLogSet;
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse.Status.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FreestyleJiraBuildInfoSenderImplTest {
@@ -54,10 +44,11 @@ public class FreestyleJiraBuildInfoSenderImplTest {
     private static final String CLOUD_ID = UUID.randomUUID().toString();
     public static final String PIPELINE_ID = UUID.randomUUID().toString();
     public static final int BUILD_NUMBER = 1;
-    private static final JiraCloudSiteConfig JIRA_SITE_CONFIG =
-            new JiraCloudSiteConfig(SITE, "clientId", "credsId");
+    private static final JiraCloudSiteConfig2 JIRA_SITE_CONFIG =
+            new JiraCloudSiteConfig2(
+                    SITE, "https://webhook.url?jenkins_server_uuid=foo", "credsId");
 
-    @Mock private JiraSiteConfigRetriever siteConfigRetriever;
+    @Mock private JiraSiteConfig2Retriever siteConfigRetriever;
 
     @Mock private SecretRetriever secretRetriever;
 
@@ -67,9 +58,7 @@ public class FreestyleJiraBuildInfoSenderImplTest {
 
     @Mock private CloudIdResolver cloudIdResolver;
 
-    @Mock private AccessTokenRetriever accessTokenRetriever;
-
-    @Mock private JiraApi buildsApi;
+    @Mock private BuildsApi buildsApi;
 
     @Mock private RunWrapperProvider runWrapperProvider;
 
@@ -85,7 +74,6 @@ public class FreestyleJiraBuildInfoSenderImplTest {
                         secretRetriever,
                         freestyleIssueKeyExtractor,
                         cloudIdResolver,
-                        accessTokenRetriever,
                         buildsApi,
                         runWrapperProvider,
                         freestyleChangeLogIssueKeyExtractor);
@@ -141,19 +129,6 @@ public class FreestyleJiraBuildInfoSenderImplTest {
 
         // then
         assertThat(response.getStatus()).isEqualTo(FAILURE_SITE_NOT_FOUND);
-    }
-
-    @Test
-    public void testSendBuildInfo_whenAccessTokenFailure() {
-        // given
-        when(accessTokenRetriever.getAccessToken(any())).thenReturn(Optional.empty());
-
-        // when
-        final JiraSendInfoResponse response = classUnderTest.sendBuildInfo(createRequest()).get(0);
-
-        // then
-        assertThat(response.getStatus())
-                .isEqualTo(JiraSendInfoResponse.Status.FAILURE_ACCESS_TOKEN);
     }
 
     @Test
@@ -275,8 +250,7 @@ public class FreestyleJiraBuildInfoSenderImplTest {
                         Collections.emptyList(),
                         Collections.emptyList(),
                         ImmutableList.of("TEST-123"));
-        when(buildsApi.postUpdate(any(), any(), any(), any(), any()))
-                .thenReturn(new PostUpdateResult<>(buildApiResponse));
+        when(buildsApi.sendBuild(any(), any())).thenReturn(buildApiResponse);
     }
 
     private void setupMocks() {
@@ -284,7 +258,6 @@ public class FreestyleJiraBuildInfoSenderImplTest {
         setupSecretRetriever();
         setupIssueKeyExtractor();
         setupCloudIdResolver();
-        setupAccessTokenRetriever();
         setupRunWrapperProvider();
     }
 
@@ -304,10 +277,6 @@ public class FreestyleJiraBuildInfoSenderImplTest {
 
     private void setupCloudIdResolver() {
         when(cloudIdResolver.getCloudId(any())).thenReturn(Optional.of(CLOUD_ID));
-    }
-
-    private void setupAccessTokenRetriever() {
-        when(accessTokenRetriever.getAccessToken(any())).thenReturn(Optional.of("access-token"));
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -332,8 +301,7 @@ public class FreestyleJiraBuildInfoSenderImplTest {
     }
 
     private void setupBuildsApiFailure() {
-        when(buildsApi.postUpdate(any(), any(), any(), any(), any()))
-                .thenReturn(new PostUpdateResult<>("Error"));
+        when(buildsApi.sendBuild(any(), any())).thenThrow(new ApiUpdateFailedException("Error"));
     }
 
     private FreestyleBuildInfoRequest createRequest() {
@@ -351,8 +319,7 @@ public class FreestyleJiraBuildInfoSenderImplTest {
                         ImmutableList.of(buildKeyResponse),
                         Collections.emptyList(),
                         Collections.emptyList());
-        when(buildsApi.postUpdate(any(), any(), any(), any(), any()))
-                .thenReturn(new PostUpdateResult<>(buildApiResponse));
+        when(buildsApi.sendBuild(any(), any())).thenReturn(buildApiResponse);
     }
 
     private void setupBuildApiBuildRejected() {
@@ -366,8 +333,7 @@ public class FreestyleJiraBuildInfoSenderImplTest {
                         Collections.emptyList(),
                         ImmutableList.of(buildResponse),
                         Collections.emptyList());
-        when(buildsApi.postUpdate(any(), any(), any(), any(), any()))
-                .thenReturn(new PostUpdateResult<>(buildApiResponse));
+        when(buildsApi.sendBuild(any(), any())).thenReturn(buildApiResponse);
     }
 
     private AbstractBuild changeSetFreestyle() {

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/common/client/JenkinsAppRequestTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/common/client/JenkinsAppRequestTest.java
@@ -3,6 +3,10 @@ package com.atlassian.jira.cloud.jenkins.common.client;
 import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.Builds;
 import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.JiraBuildInfo;
 import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.TestInfo;
+import com.atlassian.jira.cloud.jenkins.deploymentinfo.client.model.Deployments;
+import com.atlassian.jira.cloud.jenkins.deploymentinfo.client.model.Environment;
+import com.atlassian.jira.cloud.jenkins.deploymentinfo.client.model.JiraDeploymentInfo;
+import com.atlassian.jira.cloud.jenkins.deploymentinfo.client.model.Pipeline;
 import com.atlassian.jira.cloud.jenkins.provider.ObjectMapperProvider;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,7 +25,7 @@ import java.util.stream.Collectors;
 public class JenkinsAppRequestTest {
 
     @Test
-    public void serializeToJSON() throws JsonProcessingException {
+    public void serializeBuildEventToJSON() throws JsonProcessingException {
 
         Instant lastUpdated = Instant.parse("2022-02-24T05:24:36.767Z");
 
@@ -52,7 +56,48 @@ public class JenkinsAppRequestTest {
         String json = mapper.writeValueAsString(request);
         String expected =
                 new BufferedReader(
-                                new InputStreamReader(getClass().getResourceAsStream("build.json")))
+                        new InputStreamReader(getClass().getResourceAsStream("build.json")))
+                        .lines()
+                        .collect(Collectors.joining("\n"));
+        JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
+    }
+
+    @Test
+    public void serializeDeploymentEventToJSON() throws JsonProcessingException {
+
+        Instant lastUpdated = Instant.parse("2022-02-24T05:24:36.767Z");
+
+        JenkinsAppRequest request =
+                new JenkinsAppRequest(
+                        JenkinsAppRequest.RequestType.EVENT,
+                        JenkinsAppRequest.EventType.DEPLOYMENT,
+                        "pipelineId",
+                        "pipelineName",
+                        "success",
+                        lastUpdated.toString(),
+                        new Deployments(
+                                new JiraDeploymentInfo(
+                                        42,
+                                        45L,
+                                        Collections.emptySet(),
+                                        "pipelineName",
+                                        "https://url.com",
+                                        "description",
+                                        lastUpdated.toString(),
+                                        "label",
+                                        "success",
+                                        new Pipeline(
+                                                "pipelineId", "pipelineName", "https://url.com"),
+                                        new Environment("stg-east", "Staging east", "staging"),
+                                        Collections.emptyList())));
+
+        ObjectMapper mapper = new ObjectMapperProvider().objectMapper();
+        String json = mapper.writeValueAsString(request);
+        System.out.println(json);
+        String expected =
+                new BufferedReader(
+                        new InputStreamReader(
+                                getClass().getResourceAsStream("deployment.json")))
                         .lines()
                         .collect(Collectors.joining("\n"));
         JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/common/client/JenkinsAppRequestTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/common/client/JenkinsAppRequestTest.java
@@ -1,0 +1,60 @@
+package com.atlassian.jira.cloud.jenkins.common.client;
+
+import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.Builds;
+import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.JiraBuildInfo;
+import com.atlassian.jira.cloud.jenkins.buildinfo.client.model.TestInfo;
+import com.atlassian.jira.cloud.jenkins.provider.ObjectMapperProvider;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.stream.Collectors;
+
+public class JenkinsAppRequestTest {
+
+    @Test
+    public void serializeToJSON() throws JsonProcessingException {
+
+        Instant lastUpdated = Instant.parse("2022-02-24T05:24:36.767Z");
+
+        JenkinsAppRequest request =
+                new JenkinsAppRequest(
+                        JenkinsAppRequest.RequestType.EVENT,
+                        JenkinsAppRequest.EventType.BUILD,
+                        "pipelineId",
+                        "pipelineName",
+                        "success",
+                        lastUpdated.toString(),
+                        new Builds(
+                                new JiraBuildInfo(
+                                        "pipelineId",
+                                        12,
+                                        12L,
+                                        "pipelineName",
+                                        "description",
+                                        "label",
+                                        "https://url.com",
+                                        "success",
+                                        lastUpdated.toString(),
+                                        new HashSet<>(Arrays.asList("TEST-1")),
+                                        Collections.emptyList(),
+                                        new TestInfo())));
+
+        ObjectMapper mapper = new ObjectMapperProvider().objectMapper();
+        String json = mapper.writeValueAsString(request);
+        String expected =
+                new BufferedReader(
+                                new InputStreamReader(getClass().getResourceAsStream("build.json")))
+                        .lines()
+                        .collect(Collectors.joining("\n"));
+        JSONAssert.assertEquals(expected, json, JSONCompareMode.LENIENT);
+    }
+}

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/JiraDeploymentInfoSenderImplTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/JiraDeploymentInfoSenderImplTest.java
@@ -1,13 +1,12 @@
 package com.atlassian.jira.cloud.jenkins.deploymentinfo.service;
 
-import com.atlassian.jira.cloud.jenkins.auth.AccessTokenRetriever;
-import com.atlassian.jira.cloud.jenkins.common.client.JiraApi;
-import com.atlassian.jira.cloud.jenkins.common.client.PostUpdateResult;
-import com.atlassian.jira.cloud.jenkins.common.config.JiraSiteConfigRetriever;
+import com.atlassian.jira.cloud.jenkins.common.client.ApiUpdateFailedException;
+import com.atlassian.jira.cloud.jenkins.common.config.JiraSiteConfig2Retriever;
 import com.atlassian.jira.cloud.jenkins.common.model.ApiErrorResponse;
 import com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse;
 import com.atlassian.jira.cloud.jenkins.common.service.IssueKeyExtractor;
-import com.atlassian.jira.cloud.jenkins.config.JiraCloudSiteConfig;
+import com.atlassian.jira.cloud.jenkins.config.JiraCloudSiteConfig2;
+import com.atlassian.jira.cloud.jenkins.deploymentinfo.client.DeploymentsApi;
 import com.atlassian.jira.cloud.jenkins.deploymentinfo.client.model.Association;
 import com.atlassian.jira.cloud.jenkins.deploymentinfo.client.model.AssociationType;
 import com.atlassian.jira.cloud.jenkins.deploymentinfo.client.model.Command;
@@ -23,7 +22,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import hudson.AbortException;
 import hudson.model.Job;
-import hudson.model.Result;
 import hudson.model.Run;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
@@ -42,19 +40,11 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-import static com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse.Status.FAILURE_SECRET_NOT_FOUND;
-import static com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse.Status.FAILURE_SITE_CONFIG_NOT_FOUND;
-import static com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse.Status.FAILURE_SITE_NOT_FOUND;
-import static com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse.Status.SKIPPED_ISSUE_KEYS_NOT_FOUND_AND_SERVICE_IDS_ARE_EMPTY;
+import static com.atlassian.jira.cloud.jenkins.common.response.JiraSendInfoResponse.Status.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JiraDeploymentInfoSenderImplTest {
@@ -68,20 +58,20 @@ public class JiraDeploymentInfoSenderImplTest {
     private static final String CLOUD_ID2 = "my-cloud-id2";
     public static final String PIPELINE_ID = UUID.randomUUID().toString();
     public static final int BUILD_NUMBER = 1;
-    private static final JiraCloudSiteConfig JIRA_SITE_CONFIG =
-            new JiraCloudSiteConfig(SITE, "clientId", "credsId");
-    private static final JiraCloudSiteConfig JIRA_SITE_CONFIG2 =
-            new JiraCloudSiteConfig(SITE2, "clientId2", "credsId2");
+    private static final JiraCloudSiteConfig2 JIRA_SITE_CONFIG =
+            new JiraCloudSiteConfig2(
+                    SITE, "https://webhook.url?jenkins_server_uuid=foo", "credsId");
+    private static final JiraCloudSiteConfig2 JIRA_SITE_CONFIG2 =
+            new JiraCloudSiteConfig2(
+                    SITE2, "https://webhook.url?jenkins_server_uuid=bar", "credsId2");
 
-    @Mock private JiraSiteConfigRetriever siteConfigRetriever;
+    @Mock private JiraSiteConfig2Retriever siteConfigRetriever;
 
     @Mock private SecretRetriever secretRetriever;
 
     @Mock private CloudIdResolver cloudIdResolver;
 
-    @Mock private AccessTokenRetriever accessTokenRetriever;
-
-    @Mock private JiraApi deploymentsApi;
+    @Mock private DeploymentsApi deploymentsApi;
 
     @Mock private IssueKeyExtractor issueKeyExtractor;
 
@@ -96,7 +86,6 @@ public class JiraDeploymentInfoSenderImplTest {
                         siteConfigRetriever,
                         secretRetriever,
                         cloudIdResolver,
-                        accessTokenRetriever,
                         deploymentsApi,
                         issueKeyExtractor,
                         runWrapperProvider);
@@ -159,20 +148,6 @@ public class JiraDeploymentInfoSenderImplTest {
 
         // then
         assertThat(response.getStatus()).isEqualTo(FAILURE_SITE_NOT_FOUND);
-    }
-
-    @Test
-    public void testSendDeploymentInfo_whenAccessTokenFailure() {
-        // given
-        when(accessTokenRetriever.getAccessToken(any())).thenReturn(Optional.empty());
-
-        // when
-        final JiraSendInfoResponse response =
-                classUnderTest.sendDeploymentInfo(createRequest()).get(0);
-
-        // then
-        assertThat(response.getStatus())
-                .isEqualTo(JiraSendInfoResponse.Status.FAILURE_ACCESS_TOKEN);
     }
 
     @Test
@@ -333,8 +308,7 @@ public class JiraDeploymentInfoSenderImplTest {
         // then
         assertThat(response.getStatus())
                 .isEqualTo(JiraSendInfoResponse.Status.SUCCESS_DEPLOYMENT_ACCEPTED);
-        verify(deploymentsApi)
-                .postUpdate(any(), any(), any(), deploymentsArgumentCaptor.capture(), any());
+        verify(deploymentsApi).sendDeployment(any(), deploymentsArgumentCaptor.capture());
         final JiraDeploymentInfo jiraDeploymentInfo =
                 deploymentsArgumentCaptor.getValue().getDeployments().get(0);
         assertThat(jiraDeploymentInfo.getCommands())
@@ -360,8 +334,10 @@ public class JiraDeploymentInfoSenderImplTest {
             final String message = response.getMessage();
             assertThat(message).isNotBlank();
         }
-        verify(deploymentsApi, times(1)).postUpdate(eq(CLOUD_ID), any(), any(), any(), any());
-        verify(deploymentsApi, times(1)).postUpdate(eq(CLOUD_ID2), any(), any(), any(), any());
+        verify(deploymentsApi, times(1))
+                .sendDeployment(eq(JIRA_SITE_CONFIG.getWebhookUrl()), any());
+        verify(deploymentsApi, times(1))
+                .sendDeployment(eq(JIRA_SITE_CONFIG2.getWebhookUrl()), any());
     }
 
     @Test
@@ -377,7 +353,7 @@ public class JiraDeploymentInfoSenderImplTest {
         assertThat(responses).hasSize(1);
         assertThat(responses.get(0).getStatus())
                 .isEqualTo(JiraSendInfoResponse.Status.FAILURE_DEPLOYMENT_GATING_MANY_JIRAS);
-        verify(deploymentsApi, times(0)).postUpdate(any(), any(), any(), any(), any());
+        verify(deploymentsApi, times(0)).sendDeployment(any(), any());
     }
 
     @Test
@@ -450,7 +426,6 @@ public class JiraDeploymentInfoSenderImplTest {
         setupSecretRetriever();
         setupCloudIdResolver();
         setupChangeLogExtractor();
-        setupAccessTokenRetriever();
         setupRunWrapperProvider();
     }
 
@@ -468,10 +443,6 @@ public class JiraDeploymentInfoSenderImplTest {
     private void setupCloudIdResolver() {
         when(cloudIdResolver.getCloudId(eq("https://" + SITE))).thenReturn(Optional.of(CLOUD_ID));
         when(cloudIdResolver.getCloudId(eq("https://" + SITE2))).thenReturn(Optional.of(CLOUD_ID2));
-    }
-
-    private void setupAccessTokenRetriever() {
-        when(accessTokenRetriever.getAccessToken(any())).thenReturn(Optional.of("access-token"));
     }
 
     private void setupChangeLogExtractor() {
@@ -506,8 +477,8 @@ public class JiraDeploymentInfoSenderImplTest {
     }
 
     private void setupDeploymentsApiFailure() {
-        when(deploymentsApi.postUpdate(any(), any(), any(), any(), any()))
-                .thenReturn(new PostUpdateResult<>("Error"));
+        when(deploymentsApi.sendDeployment(any(), any()))
+                .thenThrow(new ApiUpdateFailedException("Error"));
     }
 
     private void setupDeploymentsApiDeploymentAccepted() {
@@ -518,8 +489,7 @@ public class JiraDeploymentInfoSenderImplTest {
                         ImmutableList.of(deploymentKeyResponse),
                         Collections.emptyList(),
                         Collections.emptyList());
-        when(deploymentsApi.postUpdate(any(), any(), any(), any(), any()))
-                .thenReturn(new PostUpdateResult<>(deploymentApiResponse));
+        when(deploymentsApi.sendDeployment(any(), any())).thenReturn(deploymentApiResponse);
     }
 
     private void setupDeploymentsApiDeploymentRejected() {
@@ -535,8 +505,7 @@ public class JiraDeploymentInfoSenderImplTest {
                         Collections.emptyList(),
                         ImmutableList.of(deploymentResponse),
                         Collections.emptyList());
-        when(deploymentsApi.postUpdate(any(), any(), any(), any(), any()))
-                .thenReturn(new PostUpdateResult<>(deploymentApiResponse));
+        when(deploymentsApi.sendDeployment(any(), any())).thenReturn(deploymentApiResponse);
     }
 
     private void setupDeploymentApiUnknownIssueKeys() {
@@ -549,8 +518,7 @@ public class JiraDeploymentInfoSenderImplTest {
                                         .withAssociationType(AssociationType.ISSUE_KEYS)
                                         .withValues(ImmutableSet.of("TEST-123"))
                                         .build()));
-        when(deploymentsApi.postUpdate(any(), any(), any(), any(), any()))
-                .thenReturn(new PostUpdateResult<>(deploymentApiResponse));
+        when(deploymentsApi.sendDeployment(any(), any())).thenReturn(deploymentApiResponse);
     }
 
     private static WorkflowRun mockWorkflowRun() {

--- a/src/test/resources/com/atlassian/jira/cloud/jenkins/common/client/build.json
+++ b/src/test/resources/com/atlassian/jira/cloud/jenkins/common/client/build.json
@@ -1,0 +1,40 @@
+{
+  "requestType": "event",
+  "eventType": "build",
+  "pipelineName": "pipelineName",
+  "status": "success",
+  "lastUpdated": "2022-02-24T05:24:36.767Z",
+  "payload": {
+    "properties": {
+      "source": "jenkins"
+    },
+    "providerMetadata": {
+      "product": "jenkins"
+    },
+    "builds": [
+      {
+        "pipelineId": "pipelineId",
+        "buildNumber": 12,
+        "updateSequenceNumber": 12,
+        "displayName": "pipelineName",
+        "description": "description",
+        "label": "label",
+        "url": "https://url.com",
+        "state": "success",
+        "lastUpdated": "2022-02-24T05:24:36.767Z",
+        "issueKeys": [
+          "TEST-1"
+        ],
+        "references": [],
+        "testInfo": {
+          "totalNumber": null,
+          "numberPassed": null,
+          "numberFailed": null,
+          "numberSkipped": null
+        },
+        "schemaVersion": "1.0"
+      }
+    ]
+  },
+  "pipelineId": "pipelineId"
+}

--- a/src/test/resources/com/atlassian/jira/cloud/jenkins/common/client/deployment.json
+++ b/src/test/resources/com/atlassian/jira/cloud/jenkins/common/client/deployment.json
@@ -1,0 +1,40 @@
+{
+  "requestType": "event",
+  "eventType": "deployment",
+  "pipelineName": "pipelineName",
+  "status": "success",
+  "lastUpdated": "2022-02-24T05:24:36.767Z",
+  "payload": {
+    "properties": {
+      "source": "jenkins"
+    },
+    "providerMetadata": {
+      "product": "jenkins"
+    },
+    "deployments": [
+      {
+        "deploymentSequenceNumber": 42,
+        "updateSequenceNumber": 45,
+        "associations": [],
+        "displayName": "pipelineName",
+        "url": "https://url.com",
+        "description": "description",
+        "lastUpdated": "2022-02-24T05:24:36.767Z",
+        "label": "label",
+        "state": "success",
+        "pipeline": {
+          "id": "pipelineId",
+          "displayName": "pipelineName",
+          "url": "https://url.com"
+        },
+        "environment": {
+          "id": "stg-east",
+          "displayName": "Staging east",
+          "type": "staging"
+        },
+        "schemaVersion": "1.0"
+      }
+    ]
+  },
+  "pipelineId": "pipelineId"
+}


### PR DESCRIPTION
Introduces a new `JenkinsAppApi` class that sends events to the Jenkins app instead of directly to Jira.

Migrated build and deployment events to use that class.