### PR TITLE
JST-798260: increase issue key limit to 500 

### DIFF
--- a/src/main/java/com/atlassian/jira/cloud/jenkins/common/service/IssueKeyExtractor.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/common/service/IssueKeyExtractor.java
@@ -6,7 +6,7 @@ import java.util.Set;
 
 public interface IssueKeyExtractor {
 
-    Integer ISSUE_KEY_MAX_LIMIT = 100;
+    Integer ISSUE_KEY_MAX_LIMIT = 500;
 
     Set<String> extractIssueKeys(WorkflowRun workflowRun);
 }

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/ChangeLogExtractorTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/deploymentinfo/service/ChangeLogExtractorTest.java
@@ -103,7 +103,7 @@ public class ChangeLogExtractorTest {
                 changeLogExtractor.extractIssueKeys(workflowRun, PipelineLogger.noopInstance());
 
         // then
-        assertThat(issueKeys).hasSize(100);
+        assertThat(issueKeys).hasSize(500);
     }
 
     private WorkflowRun workflowRunWithNoChangeSets() {
@@ -170,7 +170,7 @@ public class ChangeLogExtractorTest {
     }
 
     private WorkflowRun workflowRunWithIssuesAboveLimit() {
-        int count = 105;
+        int count = 505;
         Object[] changeSetEntries = new Object[count];
         for (int i = 0; i < count; i++) {
             final ChangeLogSet.Entry entry = mock(ChangeLogSet.Entry.class);

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/util/IssueKeyStringExtractorTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/util/IssueKeyStringExtractorTest.java
@@ -59,11 +59,11 @@ public class IssueKeyStringExtractorTest {
 
         final Set<IssueKey> issuesKeys = IssueKeyStringExtractor.extractIssueKeys(commitWithLongMessage);
 
-        assertThat(issuesKeys).hasSize(100); // instead of 110
+        assertThat(issuesKeys).hasSize(500); // instead of 510
     }
 
     private String getLongMessage() {
-        return IntStream.range(1, 110)
+        return IntStream.range(1, 510)
                 .mapToObj(seq -> "TEST-" + seq)
                 .reduce("Commit message",
                         (accumulator, element) -> accumulator + " TEST-" + element);


### PR DESCRIPTION
The Jira API allows 500 issue keys per entity (deployment, build). But the Jenkins plugin is cutting off at 100 currently. So, raising the limit