### PR TITLE
ARC-1510: extract issue keys from env vars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>com.atlassian.jira.software.cloud.jenkins</groupId>
     <artifactId>atlassian-jira-software-cloud</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
+    <version>2.0.6-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/util/BranchNameIssueKeyExtractor.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/util/BranchNameIssueKeyExtractor.java
@@ -7,8 +7,8 @@ import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMRevisionAction;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -25,29 +25,68 @@ public class BranchNameIssueKeyExtractor implements IssueKeyExtractor {
         // The action is not injected for Pipeline (single branch) jobs
         final SCMRevisionAction scmAction = build.getAction(SCMRevisionAction.class);
 
-        if (scmAction == null) {
+        final Set<String> issueKeys = new HashSet<>();
+
+        if (scmAction != null) {
+            final SCMRevision revision = scmAction.getRevision();
+            final ScmRevision scmRevision = new ScmRevision(revision.getHead().getName());
+            issueKeys.addAll(extractIssueKeys(scmRevision.getHead()));
+
             pipelineLogger.debug(
                     String.format(
-                            "Could not extract issue keys from branch name of build %s due to: SCMRevisionAction is null",
-                            build.number));
-            return Collections.emptySet();
+                            "Extracted issue keys from scmRevision.getHead() (%s): %s",
+                            scmRevision.getHead(), issueKeys));
+        } else {
+            pipelineLogger.debug(
+                    "Not extracting issue keys from scmRevision.getHead() because it's not set");
         }
 
-        final SCMRevision revision = scmAction.getRevision();
-        final ScmRevision scmRevision = new ScmRevision(revision.getHead().getName());
+        final Map<String, String> envVars = build.getEnvVars();
 
-        Set<String> issueKeys = extractIssueKeys(scmRevision);
+        // You can get an overview of a Jenkins server's environment variables by opening
+        // http://your-jenkins-server/env-vars.html
+
+        // For a multibranch project, this will be set to the name of the branch being built, for example in case you
+        // wish to deploy to production from master but not from feature branches; if corresponding to some kind of
+        // change request, the name is generally arbitrary
+        final String branchNameEnvVar = envVars.get("BRANCH_NAME");
+        if (branchNameEnvVar != null) {
+            issueKeys.addAll(extractIssueKeys(branchNameEnvVar));
+            pipelineLogger.debug(
+                    String.format(
+                            "Extracted issue keys from env var BRANCH_NAME (%s): %s",
+                            branchNameEnvVar, issueKeys));
+        } else {
+            pipelineLogger.debug(
+                    "Not extracting issue keys from environment variable BRANCH_NAME because it's not set");
+        }
+
+        // For a multibranch project corresponding to some kind of change request, this will be set to the name of the
+        // actual head on the source control system which may or may not be different from BRANCH_NAME. For example
+        // in GitHub or Bitbucket this would have the name of the origin branch whereas BRANCH_NAME would be
+        // something like PR-24.
+        final String changeBranchEnvVar = envVars.get("CHANGE_BRANCH");
+        if (changeBranchEnvVar != null) {
+            issueKeys.addAll(extractIssueKeys(changeBranchEnvVar));
+            pipelineLogger.debug(
+                    String.format(
+                            "Extracted issue keys from env var CHANGE_BRANCH (%s): %s",
+                            changeBranchEnvVar, issueKeys));
+        } else {
+            pipelineLogger.debug(
+                    "Not extracting issue keys from environment variable CHANGE_BRANCH because it's not set");
+        }
 
         pipelineLogger.debug(
                 String.format(
-                        "Extracted the following issue keys out of branch name '%s': %s",
-                        scmRevision.getHead(), Arrays.toString(issueKeys.toArray())));
+                        "Extracted the following issue keys out of branch name: %s",
+                        issueKeys.toArray()));
 
         return issueKeys;
     }
 
-    private Set<String> extractIssueKeys(final ScmRevision scmRevision) {
-        return IssueKeyStringExtractor.extractIssueKeys(scmRevision.getHead())
+    private Set<String> extractIssueKeys(final String stringWithIssueKeys) {
+        return IssueKeyStringExtractor.extractIssueKeys(stringWithIssueKeys)
                 .stream()
                 .map(IssueKey::toString)
                 .collect(Collectors.toSet());

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/util/BranchNameIssueKeyExtractor.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/util/BranchNameIssueKeyExtractor.java
@@ -80,7 +80,7 @@ public class BranchNameIssueKeyExtractor implements IssueKeyExtractor {
         pipelineLogger.debug(
                 String.format(
                         "Extracted the following issue keys out of branch name: %s",
-                        issueKeys.toArray()));
+                        issueKeys));
 
         return issueKeys;
     }

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/util/BranchNameIssueKeyExtractorTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/util/BranchNameIssueKeyExtractorTest.java
@@ -10,6 +10,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,13 +36,21 @@ public class BranchNameIssueKeyExtractorTest {
         final SCMRevisionAction scmRevisionAction =
                 new SCMRevisionAction(new GitSCMSource(""), new GitBranchSCMRevision(head, ""));
         when(mockWorkflowRun.getAction(SCMRevisionAction.class)).thenReturn(scmRevisionAction);
+        when(mockWorkflowRun.getEnvVars())
+                .thenReturn(
+                        new HashMap<String, String>() {
+                            {
+                                put("BRANCH_NAME", "DEP-56");
+                                put("CHANGE_BRANCH", "DEP-57");
+                            }
+                        });
 
         // when
         final Set<String> issueKeys =
                 classUnderTest.extractIssueKeys(mockWorkflowRun, PipelineLogger.noopInstance());
 
         // then
-        assertThat(issueKeys).containsExactlyInAnyOrder("TEST-123");
+        assertThat(issueKeys).containsExactlyInAnyOrder("TEST-123", "DEP-56", "DEP-57");
     }
 
     @Test


### PR DESCRIPTION
There's an open support case where the Jenkins API returns something like "PR-1" as the branch name when the branch is from a pull request. This means that the correct issue key will never be extracted from the branch name in these cases.

This PR also looks for issue keys in the env vars BRANCH_NAME and CHANGE_BRANCH to avoid this problem  

