### PR TITLE
ARC-1510: extract issue keys from env vars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>com.atlassian.jira.software.cloud.jenkins</groupId>
     <artifactId>atlassian-jira-software-cloud</artifactId>
-    <version>2.0.5-SNAPSHOT</version>
+    <version>2.0.6-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/util/BranchNameIssueKeyExtractor.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/util/BranchNameIssueKeyExtractor.java
@@ -3,15 +3,16 @@ package com.atlassian.jira.cloud.jenkins.util;
 import com.atlassian.jira.cloud.jenkins.common.model.IssueKey;
 import com.atlassian.jira.cloud.jenkins.common.service.IssueKeyExtractor;
 import com.atlassian.jira.cloud.jenkins.logging.PipelineLogger;
+import hudson.util.LogTaskListener;
 import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMRevisionAction;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
@@ -43,7 +44,13 @@ public class BranchNameIssueKeyExtractor implements IssueKeyExtractor {
                     "Not extracting issue keys from scmRevision.getHead() because it's not set");
         }
 
-        final Map<String, String> envVars = build.getEnvVars();
+        final Map<String, String> envVars;
+
+        try {
+            envVars = build.getEnvironment(new LogTaskListener(Logger.getLogger(BranchNameIssueKeyExtractor.class.getName()), Level.INFO));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
 
         // You can get an overview of a Jenkins server's environment variables by opening
         // http://your-jenkins-server/env-vars.html

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/util/BranchNameIssueKeyExtractor.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/util/BranchNameIssueKeyExtractor.java
@@ -9,6 +9,8 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -25,29 +27,68 @@ public class BranchNameIssueKeyExtractor implements IssueKeyExtractor {
         // The action is not injected for Pipeline (single branch) jobs
         final SCMRevisionAction scmAction = build.getAction(SCMRevisionAction.class);
 
-        if (scmAction == null) {
+        final Set<String> issueKeys = new HashSet<>();
+
+        if (scmAction != null) {
+            final SCMRevision revision = scmAction.getRevision();
+            final ScmRevision scmRevision = new ScmRevision(revision.getHead().getName());
+            issueKeys.addAll(extractIssueKeys(scmRevision.getHead()));
+
             pipelineLogger.debug(
                     String.format(
-                            "Could not extract issue keys from branch name of build %s due to: SCMRevisionAction is null",
-                            build.number));
-            return Collections.emptySet();
+                            "Extracted issue keys from scmRevision.getHead() (%s): %s",
+                            scmRevision.getHead(), issueKeys));
+        } else {
+            pipelineLogger.debug(
+                    "Not extracting issue keys from scmRevision.getHead() because it's not set");
         }
 
-        final SCMRevision revision = scmAction.getRevision();
-        final ScmRevision scmRevision = new ScmRevision(revision.getHead().getName());
+        final Map<String, String> envVars = build.getEnvVars();
 
-        Set<String> issueKeys = extractIssueKeys(scmRevision);
+        // You can get an overview of a Jenkins server's environment variables by opening
+        // http://your-jenkins-server/env-vars.html
+
+        // For a multibranch project, this will be set to the name of the branch being built, for example in case you
+        // wish to deploy to production from master but not from feature branches; if corresponding to some kind of
+        // change request, the name is generally arbitrary
+        final String branchNameEnvVar = envVars.get("BRANCH_NAME");
+        if (branchNameEnvVar != null) {
+            issueKeys.addAll(extractIssueKeys(branchNameEnvVar));
+            pipelineLogger.debug(
+                    String.format(
+                            "Extracted issue keys from env var BRANCH_NAME (%s): %s",
+                            branchNameEnvVar, issueKeys));
+        } else {
+            pipelineLogger.debug(
+                    "Not extracting issue keys from environment variable BRANCH_NAME because it's not set");
+        }
+
+        // For a multibranch project corresponding to some kind of change request, this will be set to the name of the
+        // actual head on the source control system which may or may not be different from BRANCH_NAME. For example
+        // in GitHub or Bitbucket this would have the name of the origin branch whereas BRANCH_NAME would be
+        // something like PR-24.
+        final String changeBranchEnvVar = envVars.get("CHANGE_BRANCH");
+        if (changeBranchEnvVar != null) {
+            issueKeys.addAll(extractIssueKeys(changeBranchEnvVar));
+            pipelineLogger.debug(
+                    String.format(
+                            "Extracted issue keys from env var CHANGE_BRANCH (%s): %s",
+                            changeBranchEnvVar, issueKeys));
+        } else {
+            pipelineLogger.debug(
+                    "Not extracting issue keys from environment variable CHANGE_BRANCH because it's not set");
+        }
 
         pipelineLogger.debug(
                 String.format(
-                        "Extracted the following issue keys out of branch name '%s': %s",
-                        scmRevision.getHead(), Arrays.toString(issueKeys.toArray())));
+                        "Extracted the following issue keys out of branch name: %s",
+                        issueKeys));
 
         return issueKeys;
     }
 
-    private Set<String> extractIssueKeys(final ScmRevision scmRevision) {
-        return IssueKeyStringExtractor.extractIssueKeys(scmRevision.getHead())
+    private Set<String> extractIssueKeys(final String stringWithIssueKeys) {
+        return IssueKeyStringExtractor.extractIssueKeys(stringWithIssueKeys)
                 .stream()
                 .map(IssueKey::toString)
                 .collect(Collectors.toSet());

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/util/BranchNameIssueKeyExtractor.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/util/BranchNameIssueKeyExtractor.java
@@ -55,25 +55,10 @@ public class BranchNameIssueKeyExtractor implements IssueKeyExtractor {
         // You can get an overview of a Jenkins server's environment variables by opening
         // http://your-jenkins-server/env-vars.html
 
-        // For a multibranch project, this will be set to the name of the branch being built, for example in case you
-        // wish to deploy to production from master but not from feature branches; if corresponding to some kind of
-        // change request, the name is generally arbitrary
-        final String branchNameEnvVar = envVars.get("BRANCH_NAME");
-        if (branchNameEnvVar != null) {
-            issueKeys.addAll(extractIssueKeys(branchNameEnvVar));
-            pipelineLogger.debug(
-                    String.format(
-                            "Extracted issue keys from env var BRANCH_NAME (%s): %s",
-                            branchNameEnvVar, issueKeys));
-        } else {
-            pipelineLogger.debug(
-                    "Not extracting issue keys from environment variable BRANCH_NAME because it's not set");
-        }
-
         // For a multibranch project corresponding to some kind of change request, this will be set to the name of the
-        // actual head on the source control system which may or may not be different from BRANCH_NAME. For example
-        // in GitHub or Bitbucket this would have the name of the origin branch whereas BRANCH_NAME would be
-        // something like PR-24.
+        // actual head on the source control system which may or may not be different from the branch name that is returned
+        // via revision.getHead() above. For example in GitHub or Bitbucket this would have the name of the origin branch
+        // whereas revision.getHead() would return something like PR-24.
         final String changeBranchEnvVar = envVars.get("CHANGE_BRANCH");
         if (changeBranchEnvVar != null) {
             issueKeys.addAll(extractIssueKeys(changeBranchEnvVar));

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/listeners/AutoBuildsAndDeploymentsTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/listeners/AutoBuildsAndDeploymentsTest.java
@@ -80,6 +80,7 @@ public class AutoBuildsAndDeploymentsTest {
         givenJiraAcceptsDeployments();
         givenAutoBuildsRegex(null);
         JiraSenderFactory.setInstance(mockSenderFactory);
+        JiraCloudPluginConfig.get().setDebugLogging(Boolean.TRUE);
     }
 
     private void assertListenersRegistered() {

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/listeners/AutoBuildsAndDeploymentsTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/listeners/AutoBuildsAndDeploymentsTest.java
@@ -79,6 +79,7 @@ public class AutoBuildsAndDeploymentsTest {
         givenJiraAcceptsDeployments();
         givenAutoBuildsRegex(null);
         JiraSenderFactory.setInstance(mockSenderFactory);
+        JiraCloudPluginConfig.get().setDebugLogging(Boolean.TRUE);
     }
 
     private void assertListenersRegistered() {

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/listeners/AutoBuildsAndDeploymentsTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/listeners/AutoBuildsAndDeploymentsTest.java
@@ -95,18 +95,13 @@ public class AutoBuildsAndDeploymentsTest {
 
         logger.info("found {} registered pipeline listeners", listenerCount);
 
-        for (int i = 1; i < listenerCount; i++) {
+        for (int i = 1; i <= listenerCount; i++) {
             jenkins.getInstance()
                     .getExtensionList(JenkinsPipelineRunListener.class)
                     .remove(0);
             logger.info("removed pipeline listener");
         }
 
-        // remove the default listener that Jenkins adds automatically, so we can override it with a custom one that
-        // is configured for the tests
-        jenkins.getInstance()
-                .getExtensionList(JenkinsPipelineRunListener.class)
-                .remove(0);
         logger.info("added custom pipeline listener for testing");
 
         jenkins.getInstance()

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/listeners/AutoBuildsAndDeploymentsTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/listeners/AutoBuildsAndDeploymentsTest.java
@@ -35,6 +35,8 @@ import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -71,6 +73,8 @@ public class AutoBuildsAndDeploymentsTest {
 
     private final IssueKeyExtractor issueKeyExtractor = Mockito.mock(IssueKeyExtractor.class);
 
+    private final Logger logger = LoggerFactory.getLogger(AutoBuildsAndDeploymentsTest.class);
+
     @Before
     public void setUp() throws Exception {
         assertListenersRegistered();
@@ -85,11 +89,25 @@ public class AutoBuildsAndDeploymentsTest {
 
     private void assertListenersRegistered() {
 
+        int listenerCount = jenkins.getInstance()
+                .getExtensionList(JenkinsPipelineRunListener.class)
+                .size();
+
+        logger.info("found {} registered pipeline listeners", listenerCount);
+
+        for (int i = 1; i < listenerCount; i++) {
+            jenkins.getInstance()
+                    .getExtensionList(JenkinsPipelineRunListener.class)
+                    .remove(0);
+            logger.info("removed pipeline listener");
+        }
+
         // remove the default listener that Jenkins adds automatically, so we can override it with a custom one that
         // is configured for the tests
         jenkins.getInstance()
                 .getExtensionList(JenkinsPipelineRunListener.class)
                 .remove(0);
+        logger.info("added custom pipeline listener for testing");
 
         jenkins.getInstance()
                 .getExtensionList(RunListener.class)

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/listeners/AutoBuildsAndDeploymentsTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/listeners/AutoBuildsAndDeploymentsTest.java
@@ -55,12 +55,13 @@ import static org.mockito.Mockito.*;
 public class AutoBuildsAndDeploymentsTest {
 
     private static final String SITE = "example.atlassian.net";
-    private static final String CLIENT_ID = UUID.randomUUID().toString();
     private static final String CREDENTIAL_ID = UUID.randomUUID().toString();
 
-    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
 
-    @Rule public JenkinsRule jenkins = new JenkinsRule();
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
 
     private final JiraSenderFactory mockSenderFactory = mock(JiraSenderFactory.class);
 
@@ -94,22 +95,22 @@ public class AutoBuildsAndDeploymentsTest {
 
         // Checking that the JenkinsPipelineRunListener is registered.
         assertThat(
-                        jenkins.getInstance()
-                                .getExtensionList(RunListener.class)
-                                .stream()
-                                .filter(listener -> listener instanceof JenkinsPipelineRunListener)
-                                .findFirst())
+                jenkins.getInstance()
+                        .getExtensionList(RunListener.class)
+                        .stream()
+                        .filter(listener -> listener instanceof JenkinsPipelineRunListener)
+                        .findFirst())
                 .isNotEmpty();
 
         // Checking that the JenkinsPipelineGraphListener is registered.
         assertThat(
-                        jenkins.getInstance()
-                                .getExtensionList(GraphListener.class)
-                                .stream()
-                                .filter(
-                                        listener ->
-                                                listener instanceof JenkinsPipelineGraphListener)
-                                .findFirst())
+                jenkins.getInstance()
+                        .getExtensionList(GraphListener.class)
+                        .stream()
+                        .filter(
+                                listener ->
+                                        listener instanceof JenkinsPipelineGraphListener)
+                        .findFirst())
                 .isNotEmpty();
     }
 
@@ -200,8 +201,8 @@ public class AutoBuildsAndDeploymentsTest {
 
     @Test
     public void
-            whenAutoBuildsRegexMatching_thenSendsInProgressAndSuccessBuildEventsForFirstMatchingStep()
-                    throws Exception {
+    whenAutoBuildsRegexMatching_thenSendsInProgressAndSuccessBuildEventsForFirstMatchingStep()
+            throws Exception {
         WorkflowJob workflow = givenWorkflowFromFile("auto-build-with-multiple-build-steps.groovy");
         givenAutoBuildsEnabled();
         givenAutoBuildsRegex("^build.*$");

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/util/BranchNameIssueKeyExtractorTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/util/BranchNameIssueKeyExtractorTest.java
@@ -10,6 +10,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,14 +36,23 @@ public class BranchNameIssueKeyExtractorTest {
         final SCMRevisionAction scmRevisionAction =
                 new SCMRevisionAction(new GitSCMSource(""), new GitBranchSCMRevision(head, ""));
         when(mockWorkflowRun.getAction(SCMRevisionAction.class)).thenReturn(scmRevisionAction);
+        when(mockWorkflowRun.getEnvVars())
+                .thenReturn(
+                        new HashMap<String, String>() {
+                            {
+                                put("BRANCH_NAME", "DEP-56");
+                                put("CHANGE_BRANCH", "DEP-57");
+                            }
+                        });
 
         // when
         final Set<String> issueKeys =
                 classUnderTest.extractIssueKeys(mockWorkflowRun, PipelineLogger.noopInstance());
 
         // then
-        assertThat(issueKeys).containsExactlyInAnyOrder("TEST-123");
+        assertThat(issueKeys).containsExactlyInAnyOrder("TEST-123", "DEP-56", "DEP-57");
     }
+
 
     @Test
     public void testExtractIssueKeys_whenScmRevisionActionNull() {


### PR DESCRIPTION
This PR modifies the issue key extraction from the branch name to also include the environment variable CHANGE_BRANCH that Jenkins injects to a pipeline. The previous solution only looked in the branch name provided by the Jenkins API, which looks something like "PR-1" when the branch is a pull request branch. This means that the actual branch name was not checked for issue keys in those cases!

The problem with looking in the env var is that this env var is also injected in the CI build of this project, which led to some tests failing. So I also had to make the tests more lenient so they run both locally and in the CI.