### PR TITLE
NONE update list of developers

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+**What's in this PR?**
+
+**Why**
+
+**Added feature flags**
+
+**Affected issues**  
+_Jira Issues_
+
+**How has this been tested?**  
+_Include how to test if applicable_
+
+**What's Next?**

--- a/pom.xml
+++ b/pom.xml
@@ -47,15 +47,19 @@
         <developer>
             <id>bgvozdev</id>
             <name>Boris Gvozdev</name>
-        </developer>        
+        </developer>
         <developer>
-            <id>Harminder84</id>
-            <name>Harminder Singh</name>
-        </developer>        
+            <id>rachellerathbone</id>
+            <name>Rachelle Rathbone</name>
+        </developer>
         <developer>
             <id>gxueatlassian</id>
             <name>Gary Xue</name>
-        </developer>        
+        </developer>
+        <developer>
+            <id>joshkay10</id>
+            <name>Josh Kay</name>
+        </developer>
     </developers>
 
     <scm>


### PR DESCRIPTION
Updating developers tag to reflect current team and added a PR template to override the jenkinsci one (added the same as what's in our other services).

