### PR TITLE
ARC-2473 bump minor version to fix vuln

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <archunit.version>0.9.2</archunit.version>
         <jsonassert.version>1.5.1</jsonassert.version>
         <resilience4j.version>1.4.0</resilience4j.version>
-        <jwt.version>3.18.3</jwt.version>
+        <jwt.version>3.19.4</jwt.version>
     </properties>
     <name>Atlassian Jira Software Cloud</name>
     <description>Atlassian Jira Software Cloud Jenkins Integration</description>


### PR DESCRIPTION
**What's in this PR?**
Bumped the minor version of the java-jwt package.

**Why**
Version 3.18.3 has 3 identified VULNs https://mvnrepository.com/artifact/com.auth0/java-jwt/3.18.3. Thankfully we didn't need to do a major version bump as 3.19.4 has no VULNs.

**Affected issues**  
ARC-2473

**How has this been tested?**  
Locally and uploaded to our server and let the polli checks run.

