### PR TITLE
ARC-2758 - send config data on loaded event

### DIFF
--- a/src/main/java/com/atlassian/jira/cloud/jenkins/common/client/JenkinsAppApi.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/common/client/JenkinsAppApi.java
@@ -25,8 +25,6 @@ import java.util.logging.Logger;
 
 public abstract class JenkinsAppApi<ResponseEntity> {
 
-    // TODO TEMP CODE REMOVE - IF THIS MAKES IT TO PR TSK TSK
-    private static final Logger LOGGER = Logger.getLogger(JenkinsAppApi.class.getName());
     private static final MediaType JSON_CONTENT_TYPE =
             MediaType.get("application/json; charset=utf-8");
     private static final MediaType JWT_CONTENT_TYPE = MediaType.get("application/jwt");
@@ -77,18 +75,8 @@ public abstract class JenkinsAppApi<ResponseEntity> {
             Request request = new Request.Builder().url(webhookUrl).post(body).build();
             final Response response = httpClient.newCall(request).execute();
             checkForErrorResponse(response, pipelineLogger);
-            LOGGER.info("SUCCESSFUL SAVE");
-            LOGGER.info("SUCCESSFUL SAVE");
-            LOGGER.info("SUCCESSFUL SAVE");
-            LOGGER.info("SUCCESSFUL SAVE");
-            LOGGER.info("SUCCESSFUL SAVE");
-            LOGGER.info("SUCCESSFUL SAVE");
             return handleResponseBody(response, responseClass);
         } catch (Exception e) {
-            LOGGER.info("WE HAD A PROBLEM WITH THE SAVE");
-            LOGGER.info("WE HAD A PROBLEM WITH THE SAVE");
-            LOGGER.info("WE HAD A PROBLEM WITH THE SAVE");
-            LOGGER.info(e.getMessage());
             throw handleError(e);
         }
     }

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/common/client/JenkinsAppApi.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/common/client/JenkinsAppApi.java
@@ -1,5 +1,6 @@
 package com.atlassian.jira.cloud.jenkins.common.client;
 
+import com.atlassian.jira.cloud.jenkins.listeners.InitializePluginListener;
 import com.atlassian.jira.cloud.jenkins.logging.PipelineLogger;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
@@ -20,9 +21,12 @@ import java.io.NotSerializableException;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Objects;
+import java.util.logging.Logger;
 
 public abstract class JenkinsAppApi<ResponseEntity> {
 
+    // TODO TEMP CODE REMOVE - IF THIS MAKES IT TO PR TSK TSK
+    private static final Logger LOGGER = Logger.getLogger(JenkinsAppApi.class.getName());
     private static final MediaType JSON_CONTENT_TYPE =
             MediaType.get("application/json; charset=utf-8");
     private static final MediaType JWT_CONTENT_TYPE = MediaType.get("application/jwt");
@@ -73,8 +77,18 @@ public abstract class JenkinsAppApi<ResponseEntity> {
             Request request = new Request.Builder().url(webhookUrl).post(body).build();
             final Response response = httpClient.newCall(request).execute();
             checkForErrorResponse(response, pipelineLogger);
+            LOGGER.info("SUCCESSFUL SAVE");
+            LOGGER.info("SUCCESSFUL SAVE");
+            LOGGER.info("SUCCESSFUL SAVE");
+            LOGGER.info("SUCCESSFUL SAVE");
+            LOGGER.info("SUCCESSFUL SAVE");
+            LOGGER.info("SUCCESSFUL SAVE");
             return handleResponseBody(response, responseClass);
         } catch (Exception e) {
+            LOGGER.info("WE HAD A PROBLEM WITH THE SAVE");
+            LOGGER.info("WE HAD A PROBLEM WITH THE SAVE");
+            LOGGER.info("WE HAD A PROBLEM WITH THE SAVE");
+            LOGGER.info(e.getMessage());
             throw handleError(e);
         }
     }

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/listeners/InitializePluginListener.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/listeners/InitializePluginListener.java
@@ -17,8 +17,8 @@ import static com.atlassian.jira.cloud.jenkins.util.IpAddressProvider.getIpAddre
 
 public class InitializePluginListener extends Plugin {
     private static final Logger LOGGER = Logger.getLogger(InitializePluginListener.class.getName());
-    private transient PluginConfigApi pluginConfigApi;
-    private transient SecretRetriever secretRetriever;
+    transient PluginConfigApi pluginConfigApi;
+    transient SecretRetriever secretRetriever;
 
     public InitializePluginListener() {
         this.secretRetriever = new SecretRetriever();
@@ -28,14 +28,11 @@ public class InitializePluginListener extends Plugin {
     @Override
     public void postInitialize() throws Exception {
         super.postInitialize();
-        Jenkins jenkins = Jenkins.getInstanceOrNull();
-        if (jenkins != null) {
-            JiraCloudPluginConfig config = JiraCloudPluginConfig.get();
-            sendConfigDataToJira(config);
-        }
+        JiraCloudPluginConfig config = JiraCloudPluginConfig.get();
+        sendConfigDataToJira(config);
     }
 
-    private void sendConfigDataToJira(final JiraCloudPluginConfig config) {
+    void sendConfigDataToJira(final JiraCloudPluginConfig config) {
         for (JiraCloudSiteConfig siteConfig : config.getSites()) {
             String webhookUrl = siteConfig.getWebhookUrl();
             String credentialsId = siteConfig.getCredentialsId();
@@ -43,14 +40,14 @@ public class InitializePluginListener extends Plugin {
             final Optional<String> maybeSecret = this.secretRetriever.getSecretFor(credentialsId);
             try {
                 this.pluginConfigApi.sendConnectionData(
-                    webhookUrl,
-                    maybeSecret.get(),
-                    getIpAddress(),
-                    config.getAutoBuildsEnabled(),
-                    config.getAutoBuildsRegex(),
-                    config.getAutoDeploymentsEnabled(),
-                    config.getAutoDeploymentsRegex(),
-                    PipelineLogger.noopInstance());
+                        webhookUrl,
+                        maybeSecret.get(),
+                        getIpAddress(),
+                        config.getAutoBuildsEnabled(),
+                        config.getAutoBuildsRegex(),
+                        config.getAutoDeploymentsEnabled(),
+                        config.getAutoDeploymentsRegex(),
+                        PipelineLogger.noopInstance());
             } catch (Exception e) {
                 LOGGER.severe(e.getMessage());
             }

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/listeners/InitializePluginListener.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/listeners/InitializePluginListener.java
@@ -38,10 +38,12 @@ public class InitializePluginListener extends Plugin {
             String credentialsId = siteConfig.getCredentialsId();
 
             final Optional<String> maybeSecret = this.secretRetriever.getSecretFor(credentialsId);
+            String secret = maybeSecret.orElse("");
+            
             try {
                 this.pluginConfigApi.sendConnectionData(
                         webhookUrl,
-                        maybeSecret.get(),
+                        secret,
                         getIpAddress(),
                         config.getAutoBuildsEnabled(),
                         config.getAutoBuildsRegex(),

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/listeners/InitializePluginListener.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/listeners/InitializePluginListener.java
@@ -1,0 +1,59 @@
+package com.atlassian.jira.cloud.jenkins.listeners;
+
+import com.atlassian.jira.cloud.jenkins.config.JiraCloudPluginConfig;
+import com.atlassian.jira.cloud.jenkins.config.JiraCloudSiteConfig;
+import com.atlassian.jira.cloud.jenkins.logging.PipelineLogger;
+import com.atlassian.jira.cloud.jenkins.pluginConfigApi.PluginConfigApi;
+import com.atlassian.jira.cloud.jenkins.util.SecretRetriever;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hudson.Plugin;
+import jenkins.model.Jenkins;
+import okhttp3.OkHttpClient;
+
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static com.atlassian.jira.cloud.jenkins.util.IpAddressProvider.getIpAddress;
+
+public class InitializePluginListener extends Plugin {
+    private static final Logger LOGGER = Logger.getLogger(InitializePluginListener.class.getName());
+    private transient PluginConfigApi pluginConfigApi;
+    private transient SecretRetriever secretRetriever;
+
+    public InitializePluginListener() {
+        this.secretRetriever = new SecretRetriever();
+        this.pluginConfigApi = new PluginConfigApi(new OkHttpClient(), new ObjectMapper());
+    }
+
+    @Override
+    public void postInitialize() throws Exception {
+        super.postInitialize();
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins != null) {
+            JiraCloudPluginConfig config = JiraCloudPluginConfig.get();
+            sendConfigDataToJira(config);
+        }
+    }
+
+    private void sendConfigDataToJira(final JiraCloudPluginConfig config) {
+        for (JiraCloudSiteConfig siteConfig : config.getSites()) {
+            String webhookUrl = siteConfig.getWebhookUrl();
+            String credentialsId = siteConfig.getCredentialsId();
+
+            final Optional<String> maybeSecret = this.secretRetriever.getSecretFor(credentialsId);
+            try {
+                this.pluginConfigApi.sendConnectionData(
+                    webhookUrl,
+                    maybeSecret.get(),
+                    getIpAddress(),
+                    config.getAutoBuildsEnabled(),
+                    config.getAutoBuildsRegex(),
+                    config.getAutoDeploymentsEnabled(),
+                    config.getAutoDeploymentsRegex(),
+                    PipelineLogger.noopInstance());
+            } catch (Exception e) {
+                LOGGER.severe(e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/resources/com/atlassian/jira/cloud/jenkins/configuration/config.jelly
+++ b/src/main/resources/com/atlassian/jira/cloud/jenkins/configuration/config.jelly
@@ -6,6 +6,7 @@
             <link rel="stylesheet" type="text/css" href="${resURL}/plugin/atlassian-jira-software-cloud/config.css"/>
             <script src="${resURL}/plugin/atlassian-jira-software-cloud/config.js"/>
             <script src="${resURL}/plugin/atlassian-jira-software-cloud/regexTester.js"/>
+            <j:set var="descriptor" value="${it.descriptor}" />
 
             <h1>Atlassian Software Cloud</h1>
             <p>Send build and deployment data to connected Jira Software Cloud sites.</p>

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/config/ConfigManagementLinkTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/config/ConfigManagementLinkTest.java
@@ -178,7 +178,6 @@ public class ConfigManagementLinkTest {
 
         when(mockRequest.getSubmittedForm()).thenReturn(formData);
 
-        //        PowerMockito.mockStatic(Stapler.class);
         StaplerResponse mockStaplerResponse = mock(StaplerResponse.class);
 
         // when

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/listeners/InitializePluginListenerTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/listeners/InitializePluginListenerTest.java
@@ -44,27 +44,24 @@ public class InitializePluginListenerTest {
 
     @Test
     public void testSendConfigDataToJira() throws Exception {
-        // Create a mock JiraCloudPluginConfig
+        // Given
         JiraCloudPluginConfig config = mock(JiraCloudPluginConfig.class);
         when(config.getAutoBuildsRegex()).thenReturn("Cat");
         when(config.getAutoBuildsEnabled()).thenReturn(true);
         when(config.getAutoDeploymentsRegex()).thenReturn("Dog");
         when(config.getAutoDeploymentsEnabled()).thenReturn(true);
 
-        // Create a mock JiraCloudSiteConfig
         JiraCloudSiteConfig siteConfig = mock(JiraCloudSiteConfig.class);
         when(siteConfig.getWebhookUrl()).thenReturn("https://example.com/webhook");
         when(siteConfig.getCredentialsId()).thenReturn("creds");
 
-        // Add the mock site config to the plugin config
         List<JiraCloudSiteConfig> sites = new ArrayList<>();
         sites.add(siteConfig);
         when(config.getSites()).thenReturn(sites);
 
-        // Mock the behavior of the secret retriever
         when(secretRetriever.getSecretFor(anyString())).thenReturn(Optional.of("secret"));
 
-        // Fire the "test"
+        // When
         initializePluginListener.sendConfigDataToJira(config);
 
         // Then

--- a/src/test/java/com/atlassian/jira/cloud/jenkins/listeners/InitializePluginListenerTest.java
+++ b/src/test/java/com/atlassian/jira/cloud/jenkins/listeners/InitializePluginListenerTest.java
@@ -1,0 +1,82 @@
+
+package com.atlassian.jira.cloud.jenkins.listeners;
+
+import com.atlassian.jira.cloud.jenkins.config.JiraCloudPluginConfig;
+import com.atlassian.jira.cloud.jenkins.config.JiraCloudSiteConfig;
+import com.atlassian.jira.cloud.jenkins.logging.PipelineLogger;
+import com.atlassian.jira.cloud.jenkins.pluginConfigApi.PluginConfigApi;
+import com.atlassian.jira.cloud.jenkins.util.SecretRetriever;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.OkHttpClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import jenkins.model.Jenkins;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class InitializePluginListenerTest {
+
+    @Mock
+    private PluginConfigApi pluginConfigApi;
+
+    @Mock
+    private SecretRetriever secretRetriever;
+
+    private InitializePluginListener initializePluginListener;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        initializePluginListener = new InitializePluginListener();
+        initializePluginListener.pluginConfigApi = pluginConfigApi;
+        initializePluginListener.secretRetriever = secretRetriever;
+    }
+
+    @Test
+    public void testSendConfigDataToJira() throws Exception {
+        // Create a mock JiraCloudPluginConfig
+        JiraCloudPluginConfig config = mock(JiraCloudPluginConfig.class);
+        when(config.getAutoBuildsRegex()).thenReturn("Cat");
+        when(config.getAutoBuildsEnabled()).thenReturn(true);
+        when(config.getAutoDeploymentsRegex()).thenReturn("Dog");
+        when(config.getAutoDeploymentsEnabled()).thenReturn(true);
+
+        // Create a mock JiraCloudSiteConfig
+        JiraCloudSiteConfig siteConfig = mock(JiraCloudSiteConfig.class);
+        when(siteConfig.getWebhookUrl()).thenReturn("https://example.com/webhook");
+        when(siteConfig.getCredentialsId()).thenReturn("creds");
+
+        // Add the mock site config to the plugin config
+        List<JiraCloudSiteConfig> sites = new ArrayList<>();
+        sites.add(siteConfig);
+        when(config.getSites()).thenReturn(sites);
+
+        // Mock the behavior of the secret retriever
+        when(secretRetriever.getSecretFor(anyString())).thenReturn(Optional.of("secret"));
+
+        // Fire the "test"
+        initializePluginListener.sendConfigDataToJira(config);
+
+        // Then
+        verify(pluginConfigApi, times(1)).sendConnectionData(
+                eq("https://example.com/webhook"),
+                eq("secret"),
+                anyString(),
+                eq(true),
+                eq("Cat"),
+                eq(true),
+                eq("Dog"),
+                any(PipelineLogger.class)
+        );
+    }
+}


### PR DESCRIPTION
**What's in this PR?**
When the Plugin updates and restarts it fires a postInitialize event, we listen to that to send the current jira config to jenkins for jira. This is the same data that we send when saving config. 

**Why**
So we dont have to ask the customer to manually re-save existing data to send this config data, that would be awful and probably just wouldn't do ot
