### PR TITLE
Fixing the "JSONObject["sites"] is not a JSONArray." error

### DIFF
--- a/src/main/java/com/atlassian/jira/cloud/jenkins/config/ConfigManagementLink.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/config/ConfigManagementLink.java
@@ -37,6 +37,7 @@ import javax.inject.Inject;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -134,7 +135,8 @@ public class ConfigManagementLink extends ManagementLink
     private void sendConfigDataToJira(final JSONObject formData)
             throws JiraConnectionFailedException {
         List<String> failedSitesList = new ArrayList<>();
-        JSONArray sitesArray = formData.getJSONArray(SITES);
+        JSONArray sitesArray = getSitesFromFormInArray(formData);
+
         String ipAddress = getIpAddress();
 
         boolean autoBuildsEnabled = formData.has(AUTO_BUILDS);
@@ -211,6 +213,19 @@ public class ConfigManagementLink extends ManagementLink
             }
         }
         return formData;
+    }
+
+    @VisibleForTesting
+    JSONArray getSitesFromFormInArray(JSONObject formData) {
+        JSONArray sitesArray = new JSONArray();
+
+        if (formData.get(SITES) instanceof JSONArray) {
+            sitesArray = formData.getJSONArray(SITES);
+        } else if (formData.get(SITES) instanceof JSONObject) {
+            sitesArray.add(0, formData.getJSONObject(SITES));
+        }
+
+        return sitesArray;
     }
 
     @RequirePOST

--- a/src/main/java/com/atlassian/jira/cloud/jenkins/config/ConfigManagementLink.java
+++ b/src/main/java/com/atlassian/jira/cloud/jenkins/config/ConfigManagementLink.java
@@ -215,8 +215,7 @@ public class ConfigManagementLink extends ManagementLink
         return formData;
     }
 
-    @VisibleForTesting
-    JSONArray getSitesFromFormInArray(JSONObject formData) {
+    JSONArray getSitesFromFormInArray(final JSONObject formData) {
         JSONArray sitesArray = new JSONArray();
 
         if (formData.get(SITES) instanceof JSONArray) {


### PR DESCRIPTION
**What's in this PR?**
- Converted JSONObjects into a JSONArray for single connections.

**Why**
- When saving one single connection, it was sent as a JSONObject.
- And the `save` method only expects` JSONArray`.

**Affected issues**  
https://issues.jenkins.io/browse/JENKINS-73173
