### PR TITLE
use standard components to improve dark theme integration

### DIFF
--- a/src/main/resources/com/atlassian/jira/cloud/jenkins/configuration/config.jelly
+++ b/src/main/resources/com/atlassian/jira/cloud/jenkins/configuration/config.jelly
@@ -109,11 +109,7 @@
                             </f:section>
                         </div>
 
-                        <div class="advanced-options-accordian" onclick="toggleAdvancedOptions();">
-                            <span>Advanced settings (optional)</span>
-                            <l:icon id="advancedOptionsChevron" src="symbol-chevron-up" class="advanced-options-chevron icon-sm"/>
-                        </div>
-                        <div class="advanced-block advanced-block-default" id="advancedOptionsContainer">
+                        <f:advanced>
                             <f:section title="Builds and deployments">
                                 <div class="help-area">
                                     <div class="help display-block">
@@ -150,12 +146,12 @@
                                 <!-- Enable Debug Logging -->
                                 <f:checkbox name="${config.FIELD_NAME_DEBUG_LOGGING}" title="Collect additional details to debug issues with sent data." checked="${config.getDebugLogging()}" />
                             </f:section>
-                        </div>
+                        </f:advanced>
 
                         <!-- Submit -->
-                        <div class="sticky-save-footer">
+                        <f:bottomButtonBar>
                             <f:submit value="Save"/>
-                        </div>
+                        </f:bottomButtonBar>
                     </f:form>
                 </st:if>
             </div>

--- a/src/main/webapp/config.css
+++ b/src/main/webapp/config.css
@@ -47,44 +47,14 @@
     width: 10%;
 }
 
-.sticky-save-footer {
-    position: sticky;
-    bottom: -1px;
-    margin-top: 2em;
-    margin-left: -2em;
-    width: 100vw;
-    z-index: 998;
-    background: #fff;
-    padding: 1em 0em 1em 2em;
-}
-
 .pending-changes-alert {
     margin-left: 2em;
     color: red;
 }
 
-.sticky-save-footer button {
-    min-width: 5.625em;
-}
-
 input[type=button].validate-regex-btn {
     float: right;
     margin-top: 0.5em;
-}
-
-.advanced-options-accordian {
-    padding: 1em;
-    border-radius: 6px;
-    background-color: whitesmoke;
-    font-weight: bold;
-    display: flex;
-    justify-content: space-between;
-    margin: 2em 0;
-}
-
-.advanced-options-accordian:hover {
-    cursor: pointer;
-    color: #0062d1;
 }
 
 /* Override Jelly core layout offset issue */
@@ -98,10 +68,6 @@ tr.site-data-row.selected td {
 
 tr.site-data-row.selected td #actionsContainer {
     display: none;
-}
-
-.site-data-row {
-    background-color: #ffffff !important;
 }
 
 .site-data-row td {

--- a/src/main/webapp/config.js
+++ b/src/main/webapp/config.js
@@ -52,8 +52,6 @@ const setElementPosition = (element, position) => {
 
 const getSiteDataContainer = () => document.getElementById('siteDataContainer');
 const getShowSiteButton = () => document.getElementById('showSiteButton');
-const getAdvancedOptionsContainer = () => document.getElementById('advancedOptionsContainer');
-const getAdvancedOptionsChevron = () => document.getElementById('advancedOptionsChevron');
 
 const restoreTableSiteData = () => {
     const sitesRows = document.querySelectorAll('tr[id^="site_"]');
@@ -89,18 +87,6 @@ const hideSiteInputs = () => {
     setSiteFormContent();
     handleFormChange();
 };
-
-const toggleAdvancedOptions = () => {
-    const advancedOptionsContainer = getAdvancedOptionsContainer();
-    const advancedOptionsChevron = getAdvancedOptionsChevron();
-    if (advancedOptionsContainer.style.position === 'inherit') {
-        setElementPosition(advancedOptionsContainer, 'absolute');
-        advancedOptionsChevron.style.transform = 'rotate(0deg)';
-    } else {
-        setElementPosition(advancedOptionsContainer, 'inherit');
-        advancedOptionsChevron.style.transform = 'rotate(180deg)';
-    }
-}
 
 const toggleSaveSiteForm = (state) => {
     const activeInput = document.querySelector('#siteDataContainer [name="active"]');


### PR DESCRIPTION
**What's in this PR?**
Custom button bar and avanced accordion have been replaced with standard elements

**Why**
To better integrate with dark theme

**Added feature flags**
No feature changes

**Affected issues**  
Fixes #135 

**How has this been tested?**  
Tested with `mvn hpi:run`

**What's Next?**
